### PR TITLE
Home-row-mods; Escape top left; Combos for Q, Z and V

### DIFF
--- a/config/tc36k.keymap
+++ b/config/tc36k.keymap
@@ -179,6 +179,38 @@
             key-positions = <RB1 RB2 RB3>;
         };
 
+        // 2-key horizontal home-row combos for modifiers
+        left_alt_combo {
+            bindings = <&kp LALT>;
+            key-positions = <LM3 LM4>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+        left_ctrl_combo {
+            bindings = <&kp LCTRL>;
+            key-positions = <LM2 LM3>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+        left_gui_combo {
+            bindings = <&kp LGUI>;
+            key-positions = <LM1 LM2>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+        right_alt_combo {
+            bindings = <&kp RALT>;
+            key-positions = <RM3 RM4>;
+             layers = <DEFAULT NUM_NAV>;
+        };
+        right_ctrl_combo {
+            bindings = <&kp RCTRL>;
+            key-positions = <RM2 RM3>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+        right_gui_combo {
+            bindings = <&kp RGUI>;
+            key-positions = <RM1 RM2>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+
         // 2-key horizontal combos for rare letters
         q_combo {
             bindings = <&kp Q>;


### PR DESCRIPTION
On my 36-key keyboard, I've struggled without Escape top left, especially in non-typing (eg cancel in dialogue prompts, mode switching in Helix editor, KiCad, ...). This uses Qwerty Q as `Escape` rather than the letter `V` which is moved to a horizontal 2-key combo on the keys next to it (Qwerty `W` and `E`).

[Escape top left will match my Japanese layer, see #2]

While I already had `Q` and `Z` on a layer, with QMK/Vial and [Karabiner-Elements](https://codeberg.org/peterjc/kana-chording-ke/src/branch/main/hands-down-on-jis-macbook) I _also_ had them as 2-key horizontal combos (both bottom right). That clashes with using home row mods (HRM) so the are now bottom left/right (now Qwerty `Z` and `X` for `Q`, still Qwerty `.` and `/` for `Z`).

Finally, this adds horizontal 2-key combo HRMs for alt/ctrl/command. Shift remains primarily on the right thumb. I forget where I saw this idea, but it will hopefully have minimal false positives in normal typing...