### PR TITLE
Naginata small kana (kogaki) as a ZMK layer

### DIFF
--- a/config/tc36k.keymap
+++ b/config/tc36k.keymap
@@ -21,7 +21,8 @@
 // Aliases for my layers
 #define DEFAULT 0
 #define NAGINATA 1
-#define NUM_NAV 2
+#define KOGAKI 2
+#define NUM_NAV 3
 
 / {
     macros {
@@ -64,6 +65,20 @@
                 ;
         };
 
+        // Small kana (kogaki) macros to define as a ZMK layer
+        ng_xya: ng_xya {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp Y &kp A>;};
+        ng_xyu: ng_xyu {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp Y &kp U>;};
+        ng_xyo: ng_xyo {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp Y &kp O>;};
+        ng_xa: ng_xa {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp A>;};
+        ng_xi: ng_xi {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp I>;};
+        ng_xu: ng_xu {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp U>;};
+        ng_xe: ng_xe {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp E>;};
+        ng_xo: ng_xo {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp O>;}; 
+        ng_xwa: ng_xwa {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp W &kp A>;};
+        ng_xtu: ng_xtu {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp T &kp U>;};
+        ng_xke: ng_xke {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp K &kp E>;};
+        ng_xka: ng_xka {compatible = "zmk,behavior-macro"; #binding-cells = <0>; bindings = <&macro_tap &kp X &kp K &kp A>;};
+ 
     };
 };
 
@@ -103,10 +118,19 @@
         naginata_layer {
             display-name = "Naginata";
             bindings = <
-                &ng Q  &ng W  &ng E               &ng R     &ng T         &ng Y     &ng U     &ng I     &ng O      &ng P
-                &ng A  &ng S  &ng D               &ng F     &ng G         &ng H     &ng J     &ng K     &ng L      &ng SEMI
-                &ng Z  &ng X  &ng C               &ng V     &ng B         &ng N     &ng M     &ng COMMA &ng DOT    &ng SLASH
-                              &base_with_mod LGUI &ng ENTER &kp BACKSPACE &mt LSHFT LS(SPACE) &ng SPACE &mo NUM_NAV
+                &lt KOGAKI ESCAPE &ng W  &ng E               &ng R     &ng T         &ng Y     &ng U     &ng I     &ng O      &ng P
+                &ng A             &ng S  &ng D               &ng F     &ng G         &ng H     &ng J     &ng K     &ng L      &ng SEMI
+                &ng Z             &ng X  &ng C               &ng V     &ng B         &ng N     &ng M     &ng COMMA &ng DOT    &ng SLASH
+                                         &base_with_mod LGUI &ng ENTER &kp BACKSPACE &mt LSHFT LS(SPACE) &ng SPACE &mo NUM_NAV
+                >;
+        };
+        kogaki_layer {
+            display-name = "Kogaki";
+            bindings = <
+                &trans &trans  &trans &trans  &trans  &trans  &trans &ng_xyo &ng_xe  &ng_xyu
+                &trans &ng_xke &trans &ng_xka &ng_xtu &ng_xya &ng_xa &ng_xi  &ng_xu  &trans
+                &trans &trans  &trans &trans  &trans  &ng_xo  &trans &trans  &ng_xwa &trans
+                               &trans &trans  &trans  &trans  &trans &trans
                 >;
         };
 

--- a/keymap-drawer/tc36k.svg
+++ b/keymap-drawer/tc36k.svg
@@ -1,4 +1,4 @@
-<svg width="676" height="896" viewBox="0 0 676 896" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="676" height="1176" viewBox="0 0 676 1176" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -422,8 +422,9 @@ text.right {
 <g transform="translate(28, 28)" class="key keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⎋</text>
-<text x="0" y="24" class="key hold"><tspan style="font-size: 70%">Small-kana</tspan></text>
-</g>
+<a href="#Kogaki">
+<text x="0" y="24" class="key hold layer-activator">Kogaki</text>
+</a></g>
 <g transform="translate(84, 28)" class="key keypos-1">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="-24" y="0" class="key left">き</text>
@@ -626,7 +627,169 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 560)" class="layer-Num + Nav">
+<g transform="translate(30, 560)" class="layer-Kogaki">
+<text x="0" y="28" class="label" id="Kogaki">Kogaki</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 28)" class="key held keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
+</g>
+<g transform="translate(84, 28)" class="key trans keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(140, 28)" class="key trans keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(196, 28)" class="key trans keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(252, 28)" class="key trans keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(364, 28)" class="key trans keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(420, 28)" class="key trans keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(476, 28)" class="key keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ょ</text>
+</g>
+<g transform="translate(532, 28)" class="key keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ぇ</text>
+</g>
+<g transform="translate(588, 28)" class="key keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ゅ</text>
+</g>
+<g transform="translate(28, 84)" class="key trans keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(84, 84)" class="key keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ヶ</text>
+</g>
+<g transform="translate(140, 84)" class="key trans keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(196, 84)" class="key keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ヵ</text>
+</g>
+<g transform="translate(252, 84)" class="key keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">っ</text>
+</g>
+<g transform="translate(364, 84)" class="key keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ゃ</text>
+</g>
+<g transform="translate(420, 84)" class="key keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ぁ</text>
+</g>
+<g transform="translate(476, 84)" class="key keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ぃ</text>
+</g>
+<g transform="translate(532, 84)" class="key keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ぅ</text>
+</g>
+<g transform="translate(588, 84)" class="key trans keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(28, 140)" class="key trans keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(84, 140)" class="key trans keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(140, 140)" class="key trans keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(196, 140)" class="key trans keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(252, 140)" class="key trans keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(364, 140)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ぉ</text>
+</g>
+<g transform="translate(420, 140)" class="key trans keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(476, 140)" class="key trans keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(532, 140)" class="key keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="-24" y="0" class="key left">ゎ</text>
+</g>
+<g transform="translate(588, 140)" class="key trans keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(140, 196)" class="key trans keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(196, 196)" class="key trans keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(252, 196)" class="key trans keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(364, 196)" class="key trans keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(420, 196)" class="key trans keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(476, 196)" class="key trans keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g class="combo combopos-0">
+<path d="M112,168 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M112,168 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M112,168 h-22 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<rect rx="6" ry="6" x="98" y="160" width="28" height="15" class="combo"/>
+<text x="112" y="168" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-1">
+<path d="M504,168 h-78 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M504,168 h-22 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M504,168 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<rect rx="6" ry="6" x="490" y="160" width="28" height="15" class="combo"/>
+<text x="504" y="168" class="combo tap">⏎</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 840)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 28)" class="key keypos-0">

--- a/keymap-drawer/tc36k.yaml
+++ b/keymap-drawer/tc36k.yaml
@@ -38,7 +38,7 @@ layers:
   - {t: ⎵, type: high}
   - Num + Nav
   Naginata:
-  - {t: ⎋, h: Small-kana}
+  - {t: ⎋, h: Kogaki}
   - {left: き, right: ぬ}
   - {left: て, right: り}
   - {left: し, right: め}
@@ -74,6 +74,43 @@ layers:
   - {t: ⇧⎵, h: ⇧}
   - {t: ⎵, h: Kana-Shift, type: kshift}
   - Num + Nav
+  Kogaki:
+  - {type: held}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {left: ょ}
+  - {left: ぇ}
+  - {left: ゅ}
+  - {t: ▽, type: trans}
+  - {left: ヶ}
+  - {t: ▽, type: trans}
+  - {left: ヵ}
+  - {left: っ}
+  - {left: ゃ}
+  - {left: ぁ}
+  - {left: ぃ}
+  - {left: ぅ}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {left: ぉ}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {left: ゎ}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
+  - {t: ▽, type: trans}
   Num + Nav:
   - /
   - '1'

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -214,6 +214,20 @@ parse_config:
     '&ng SPACE': {'t': '⎵', 'h': 'Kana-Shift', 'type': 'kshift'}
     '&ng ENTER': {'t': '⏎', 'h': 'Kana-Shift', 'type': 'kshift'}
     '&base_with_mod LGUI': '⌘'
+    # These are macros for the small kana layer (kogaki)
+    '&ng_xya': {'left': 'ゃ'}
+    '&ng_xyu': {'left': 'ゅ'}
+    '&ng_xyo': {'left': 'ょ'}
+    '&ng_xa': {'left': 'ぁ'}
+    '&ng_xi': {'left': 'ぃ'}
+    '&ng_xu': {'left': 'ぅ'}
+    '&ng_xe': {'left': 'ぇ'}
+    '&ng_xo': {'left': 'ぉ'}
+    '&ng_xwa': {'left': 'ゎ'}
+    '&ng_xtu': {'left': 'っ'}
+    '&ng_xka': {'left': 'ヵ'}
+    '&ng_xke': {'left': 'ヶ'}
+
 draw_config:
   append_colon_to_layer_header: false
   # dark_mode: auto


### PR DESCRIPTION
If you always hold Qwerty Q first like a shift key, this should feel the same for typing the kogaki. They may be a way to do this with the existing Naginata functions, but this just uses a ZMK macro for each kogaki.

Why?

(A) Get my tap for escape change _without_ having to use a fork of zmk-naginata (see #2).

(B) We might then use some of the spare slots/combos for punctuation normally on the Naginata edit layers? There are 3~5 on the left hand which are reasonably comfy, and up to six on the right hand.