### PR TITLE
Fix double quote mod-morph; shifted punctuation on keymap

### DIFF
--- a/config/tc36k.keymap
+++ b/config/tc36k.keymap
@@ -76,7 +76,10 @@
             #binding-cells = <0>;
             bindings = <&kp SQT>, <&kp N2>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
+            // need to keep shift, and anything else too:
+            keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
         };
+
     };
 };
 
@@ -87,10 +90,10 @@
         default_layer {
             display-name = "HD Promethium";
             bindings = <
-                &kp ESCAPE &kp P  &kp G    &kp M   &kp X         &kp SLASH &kp DOT   &xquote &kp MINUS &kp EQUAL
-                &kp S      &kp N  &kp T    &kp H   &kp K         &kp COMMA &kp A     &kp E   &kp I     &kp C
-                &kp B      &kp F  &kp D    &kp L   &kp J         &kp SEMI  &kp U     &kp O   &kp Y     &kp W
-                                  &kp LGUI &kp R   &kp BACKSPACE &kp LSHFT &kp SPACE &mo NUM_NAV
+                &kp ESCAPE &kp P  &kp G    &kp M   &kp X    &kp SLASH &kp DOT   &xquote &kp MINUS &kp EQUAL
+                &kp S      &kp N  &kp T    &kp H   &kp K    &kp COMMA &kp A     &kp E   &kp I     &kp C
+                &kp B      &kp F  &kp D    &kp L   &kp J    &kp SEMI  &kp U     &kp O   &kp Y     &kp W
+                                  &kp LGUI &kp R   &kp BSPC &kp LSHFT &kp SPACE &mo NUM_NAV
             >;
         };
 
@@ -103,17 +106,17 @@
         naginata_layer {
             display-name = "Naginata";
             bindings = <
-                &ng Q  &ng W  &ng E               &ng R     &ng T         &ng Y     &ng U     &ng I     &ng O      &ng P
-                &ng A  &ng S  &ng D               &ng F     &ng G         &ng H     &ng J     &ng K     &ng L      &ng SEMI
-                &ng Z  &ng X  &ng C               &ng V     &ng B         &ng N     &ng M     &ng COMMA &ng DOT    &ng SLASH
-                              &base_with_mod LGUI &ng ENTER &kp BACKSPACE &mt LSHFT LS(SPACE) &ng SPACE &mo NUM_NAV
+                &ng Q  &ng W  &ng E               &ng R     &ng T    &ng Y     &ng U     &ng I     &ng O      &ng P
+                &ng A  &ng S  &ng D               &ng F     &ng G    &ng H     &ng J     &ng K     &ng L      &ng SEMI
+                &ng Z  &ng X  &ng C               &ng V     &ng B    &ng N     &ng M     &ng COMMA &ng DOT    &ng SLASH
+                              &base_with_mod LGUI &ng ENTER &kp BSPC &mt LSHFT LS(SPACE) &ng SPACE &mo NUM_NAV
                 >;
         };
 
         num_nav_layer {
             display-name = "Num + Nav";
             bindings = <
-                &kp KP_DIVIDE    &kp N1 &kp N2 &kp N3 &kp KP_EQUAL &kp ESCAPE &kp HOME     &kp UP     &kp END       &kp BACKSPACE
+                &kp KP_DIVIDE    &kp N1 &kp N2 &kp N3 &kp KP_EQUAL &kp ESCAPE &kp HOME     &kp UP     &kp END       &kp BSPC
                 &kp KP_MULTIPLY  &kp N4 &kp N5 &kp N6 &kp KP_PLUS  &kp PG_UP  &kp LEFT     &kp DOWN   &kp RIGHT     &kp Q
                 &mt LSHFT KP_DOT &kp N7 &kp N8 &kp N9 &kp KP_MINUS &kp PG_DN  &kp LA(LEFT) &kp RETURN &kp LA(RIGHT) &kp Z
                                         &trans &kp N0 &trans       &trans     &trans       &trans

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -138,6 +138,7 @@ parse_config:
     combo_ng_on: {'align': 'bottom', 'offset': -0.02, 'slide': 0.5, 'key': 'かな', 'height': 15}
     combo_ng_off: {'align': 'bottom', 'offset': -0.02, 'slide': -0.5, 'key': 'ABC', 'height': 15}
     pipe_sign: {'align': 'right', 'key': '|'}
+    caret_sign: {'align': 'left'}
     exclamation_mark: {'align': 'left'}
     backtick: {'key': '`'}
     at_sign: {'key': '@'}
@@ -172,13 +173,13 @@ parse_config:
     '&kp B': {'t': 'B', 'type': 'medium-low'}
     '&kp N': {'t': 'N', 'type': 'high'}
     '&kp M': {'t': 'M', 'type': 'medium'}
-    '&kp COMMA': {'t': ',', 'type': 'medium-low'}
-    '&kp DOT': {'t': '.', 'type': 'medium-low'}
+    '&kp COMMA': {'t': ',', 's': '<', 'type': 'medium-low'}
+    '&kp DOT': {'t': '.', 's': '>', 'type': 'medium-low'}
     # not in Bird mappings:
-    '&kp SLASH': {'t': '/', 'type': 'low'}
-    '&xquote': {'t': '''', 'type': 'medium-low'}  # this key is single & double quote
-    '&kp MINUS': {'t': '-', 'type': 'medium-low'}
-    '&kp EQUAL': {'t': '=', 'type': 'low'}
+    '&kp SLASH': {'t': '/', 's': '?', 'type': 'low'}
+    '&xquote': {'t': '''', 's': '"', 'type': 'medium-low'}
+    '&kp MINUS': {'t': '-', 's': '_', 'type': 'medium-low'}
+    '&kp EQUAL': {'t': '=', 's': '+', 'type': 'low'}
     '&kp SPACE': {'t': '⎵', 'type': 'high'}
      # These are the Naginata Style keys for typing in Japanese using kana:
     '&ng Q': {'t': '⎋', 'h': 'Small-kana'}


### PR DESCRIPTION
The double quote mod-morph was only working due to an interaction between ZMK and Karabiner-Elements keeping shift pressed.

See https://github.com/zmkfirmware/zmk/issues/1685 and https://github.com/pqrs-org/Karabiner-Elements/issues/3420

Also show the shifted punctuation on the keymap (had to move the caret combo).