### PR TITLE
Backspace on left-index-top like Naginata

### DIFF
--- a/config/tc36k.keymap
+++ b/config/tc36k.keymap
@@ -85,6 +85,24 @@
 
 #include "adaptive-keys.h"
 
+        dot_colon: dot_colon {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp DOT>, <&kp SEMI>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+            // need to keep shift, and anything else too:
+            keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
+        };
+
+        comma_semi: comma_semi {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp COMMA>, <&kp SEMI>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+            // do NOT want to keep shift active, but anything else is fine:
+            keep-mods = <(MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
+        };
+
     };
 };
 
@@ -95,9 +113,9 @@
         default_layer {
             display-name = "HD Promethium";
             bindings = <
-                &kp ESCAPE &ak_P  &ak_G    &ak_M   &ak_X    &kp SLASH   &kp DOT   &xquote &kp MINUS &kp EQUAL
-                &ak_S      &ak_N  &ak_T    &ak_H   &ak_K    &kp COMMA   &ak_A     &ak_E   &ak_I     &ak_C
-                &ak_B      &ak_F  &ak_D    &ak_L   &ak_J    &kp SEMI    &ak_U     &ak_O   &ak_Y     &ak_W
+                &kp ESCAPE &ak_P  &ak_G    &ak_M   &ak_X    &kp SLASH   &kp BSPC  &xquote &kp MINUS &kp EQUAL
+                &ak_S      &ak_N  &ak_T    &ak_H   &ak_K    &dot_colon  &ak_A     &ak_E   &ak_I     &ak_C
+                &ak_B      &ak_F  &ak_D    &ak_L   &ak_J    &comma_semi &ak_U     &ak_O   &ak_Y     &ak_W
                                   &kp LGUI &kp R   &kp BSPC &kp LSHFT   &kp SPACE &mo NUM_NAV
             >;
         };
@@ -352,6 +370,18 @@
         close_square {
             bindings = <&kp RIGHT_BRACKET>;
             key-positions = <RB0 RB1>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+
+        less_than {
+            bindings = <&kp LESS_THAN>;
+            key-positions = <LB3 LB4>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+
+        greater_than {
+            bindings = <&kp GREATER_THAN>;
+            key-positions = <RB3 RB4>;
             layers = <DEFAULT NUM_NAV>;
         };
 

--- a/keymap-drawer/tc36k.svg
+++ b/keymap-drawer/tc36k.svg
@@ -154,10 +154,9 @@ text.right {
 <text x="0" y="0" class="key low tap">/</text>
 <text x="0" y="-24" class="key low shifted">?</text>
 </g>
-<g transform="translate(420, 28)" class="key medium-low keypos-6">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
-<text x="0" y="0" class="key medium-low tap">.</text>
-<text x="0" y="-24" class="key medium-low shifted">&gt;</text>
+<g transform="translate(420, 28)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(476, 28)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -196,8 +195,8 @@ text.right {
 </g>
 <g transform="translate(364, 84)" class="key medium-low keypos-15">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
-<text x="0" y="0" class="key medium-low tap">,</text>
-<text x="0" y="-24" class="key medium-low shifted">&lt;</text>
+<text x="0" y="0" class="key medium-low tap">.</text>
+<text x="0" y="-24" class="key medium-low shifted">:</text>
 </g>
 <g transform="translate(420, 84)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
@@ -235,10 +234,10 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
 <text x="0" y="0" class="key low tap">J</text>
 </g>
-<g transform="translate(364, 140)" class="key low keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
-<text x="0" y="0" class="key low tap">;</text>
-<text x="0" y="-24" class="key low shifted">:</text>
+<g transform="translate(364, 140)" class="key medium-low keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,</text>
+<text x="0" y="-24" class="key medium-low shifted">;</text>
 </g>
 <g transform="translate(420, 140)" class="key medium-high keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
@@ -422,6 +421,14 @@ text.right {
 <g class="combo combopos-32">
 <rect rx="6" ry="6" x="378" y="127" width="28" height="26" class="combo"/>
 <text x="392" y="140" class="combo tap">]</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="42" y="127" width="28" height="26" class="combo"/>
+<text x="56" y="140" class="combo tap">&lt;</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="546" y="127" width="28" height="26" class="combo"/>
+<text x="560" y="140" class="combo tap">&gt;</text>
 </g>
 </g>
 </g>
@@ -901,6 +908,14 @@ text.right {
 <g class="combo combopos-25">
 <rect rx="6" ry="6" x="378" y="127" width="28" height="26" class="combo"/>
 <text x="392" y="140" class="combo tap">]</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="42" y="127" width="28" height="26" class="combo"/>
+<text x="56" y="140" class="combo tap">&lt;</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="546" y="127" width="28" height="26" class="combo"/>
+<text x="560" y="140" class="combo tap">&gt;</text>
 </g>
 </g>
 </g>

--- a/keymap-drawer/tc36k.yaml
+++ b/keymap-drawer/tc36k.yaml
@@ -7,7 +7,7 @@ layers:
   - {t: M, type: medium}
   - {t: X, type: low}
   - {t: /, s: '?', type: low}
-  - {t: ., s: '>', type: medium-low}
+  - ⌫
   - {t: '''', s: '"', type: medium-low}
   - {t: '-', s: _, type: medium-low}
   - {t: '=', s: +, type: low}
@@ -16,7 +16,7 @@ layers:
   - {t: T, type: high}
   - {t: H, type: high}
   - {t: K, type: low}
-  - {t: ',', s: <, type: medium-low}
+  - {t: ., s: ':', type: medium-low}
   - {t: A, type: high}
   - {t: E, type: high}
   - {t: I, type: high}
@@ -26,7 +26,7 @@ layers:
   - {t: D, type: medium-high}
   - {t: L, type: medium-high}
   - {t: J, type: low}
-  - {t: ;, s: ':', type: low}
+  - {t: ',', s: ;, type: medium-low}
   - {t: U, type: medium-high}
   - {t: O, type: high}
   - {t: Y, type: medium}
@@ -233,4 +233,10 @@ combos:
   l: [HD Promethium, Num + Nav]
 - p: [25, 26]
   k: ']'
+  l: [HD Promethium, Num + Nav]
+- p: [21, 20]
+  k: <
+  l: [HD Promethium, Num + Nav]
+- p: [28, 29]
+  k: '>'
   l: [HD Promethium, Num + Nav]

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -147,6 +147,8 @@ parse_config:
     at_sign: {'key': '@'}
     gbp_sign: {'key': '£'}
     tilde_sign: {'key': '~'}
+    less_than: {'key': '<'}
+    greater_than: {'key': '>'}
   raw_binding_map:
     # These are the English letters defined here to tag them by usage:
     '&kp Q': {'t': 'Q', 'type': 'low'}
@@ -177,7 +179,9 @@ parse_config:
     '&kp N': {'t': 'N', 'type': 'high'}
     '&kp M': {'t': 'M', 'type': 'medium'}
     '&kp COMMA': {'t': ',', 's': '<', 'type': 'medium-low'}
+    '&comma_semi': {'t': ',', 's': ';', 'type': 'medium-low'}
     '&kp DOT': {'t': '.', 's': '>', 'type': 'medium-low'}
+    '&dot_colon': {'t': '.', 's':':', 'type': 'medium-low'}
     # not in Bird mappings:
     '&kp SLASH': {'t': '/', 's': '?', 'type': 'low'}
     '&xquote': {'t': '''', 's': '"', 'type': 'medium-low'}


### PR DESCRIPTION
Moved dot to comma location, comma to semi-colon location.

Override shifted dot & comma to be colon & semi-colon.

Move less-than and greater-than to combos instead.

However, getting semi-colon when use shift+comma will probably fail with KE running... see notes on #6.
