### PR TITLE
Use 'Comma Shift' aka 'Comma Magic' adaptive key behaviour

### DIFF
--- a/config/adaptive-keys.h
+++ b/config/adaptive-keys.h
@@ -17,184 +17,184 @@
             #binding-cells = <0>;
             bindings = <&kp A>;
 
-            akA_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(A)>; };
+            akA_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(A)>; strict-modifiers; };
         };
         ak_B: ak_B {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp B>;
 
-            akB_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(B)>; };
+            akB_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(B)>; strict-modifiers; };
         };
         ak_C: ak_C {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp C>;
 
-            akC_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(C)>; };
+            akC_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(C)>; strict-modifiers; };
         };
         ak_D: ak_D {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp D>;
 
-            akD_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(D)>; };
+            akD_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(D)>; strict-modifiers; };
         };
         ak_E: ak_E {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp E>;
 
-            akE_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(E)>; };
+            akE_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(E)>; strict-modifiers; };
         };
         ak_F: ak_F {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp F>;
 
-            akF_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(F)>; };
-            // akF_t_v { trigger-keys = <D>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp V>; };
+            akF_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(F)>; strict-modifiers; };
+            // akF_t_v { trigger-keys = <D>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp V>; strict-modifiers; };
         };
         ak_G: ak_G {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp G>;
 
-            akG_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(G)>; };
+            akG_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(G)>; strict-modifiers; };
         };
         ak_H: ak_H {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp H>;
 
-            akH_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(H)>; };
+            akH_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(H)>; strict-modifiers; };
         };
         ak_I: ak_I {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp I>;
 
-            akI_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(I)>; };
+            akI_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(I)>; strict-modifiers; };
         };
         ak_J: ak_J {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp J>;
 
-            akJ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(J)>; };
+            akJ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(J)>; strict-modifiers; };
         };
         ak_K: ak_K {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp K>;
 
-            akK_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(K)>; };
+            akK_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(K)>; strict-modifiers; };
         };
         ak_L: ak_L {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp L>;
 
-            akL_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(L)>; };
+            akL_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(L)>; strict-modifiers; };
         };
         ak_M: ak_M {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp M>;
 
-            akM_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(M)>; };
+            akM_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(M)>; strict-modifiers; };
         };
         ak_N: ak_N {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp N>;
 
-            akN_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(N)>; };
-            // akN_t_ion { trigger-keys = <T>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp I &kp O &kp N>; };
+            akN_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(N)>; strict-modifiers; };
+            // akN_t_ion { trigger-keys = <T>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp I &kp O &kp N>; strict-modifiers; };
         };
         ak_O: ak_O {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp O>;
 
-            akO_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(O)>; };
+            akO_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(O)>; strict-modifiers; };
         };
         ak_P: ak_P {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp P>;
 
-            akP_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(P)>; };
+            akP_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(P)>; strict-modifiers; };
         };
         ak_Q: ak_Q {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp Q>;
 
-            akQ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Q)>; };
+            akQ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Q)>; strict-modifiers; };
         };
         ak_R: ak_R {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp R>;
 
-            akR_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(R)>; };
+            akR_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(R)>; strict-modifiers; };
         };
         ak_S: ak_S {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp S>;
 
-            akS_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(S)>; };
+            akS_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(S)>; strict-modifiers; };
         };
         ak_T: ak_T {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp T>;
 
-            akT_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(T)>; };
+            akT_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(T)>; strict-modifiers; };
         };
         ak_U: ak_U {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp U>;
 
-            akU_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(U)>; };
+            akU_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(U)>; strict-modifiers; };
         };
         ak_V: ak_V {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp V>;
 
-            akV_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(V)>; };
+            akV_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(V)>; strict-modifiers; };
         };
         ak_W: ak_W {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp W>;
 
-            akW_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(W)>; };
+            akW_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(W)>; strict-modifiers; };
         };
         ak_X: ak_X {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp X>;
 
-            akX_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(X)>; };
+            akX_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(X)>; strict-modifiers; };
         };
         ak_Y: ak_Y {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp Y>;
 
-            akY_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Y)>; };
+            akY_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Y)>; strict-modifiers; };
         };
         ak_Z: ak_Z {
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp Z>;
 
-            akZ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Z)>; };
+            akZ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Z)>; strict-modifiers; };
         };
 
 /*
@@ -202,6 +202,6 @@
             compatible = "zmk,behavior-adaptive-key";
             #binding-cells = <0>;
             bindings = <&kp CMMA>;
-            ak_CMMA_cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &caps_word>; };
+            ak_CMMA_cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &caps_word>; strict-modifiers; };
         };
 */

--- a/config/adaptive-keys.h
+++ b/config/adaptive-keys.h
@@ -1,0 +1,207 @@
+/*
+ * AdaptiveKey behaviors (send a different behavior based on prior key),
+ * and in particular "Comma Magic" aka "Comma Shift" by @phbonachi on Reddit.
+ * See https://github.com/moutis/zmk-config
+ *
+ * Commma almost never preceeds a letter (usually followed by space, or a number).
+ * Treat comma then letter as meaning capital letter (sends backspace then shifted
+ * letter) using urob's behavior-adaptive-key module https://github.com/urob/zmk-adaptive-key/
+ *
+ * This is overly verbose, but allows additonal "Adaptive Keys" to be defined too.
+ * (It is tempting to define the capital only ones with a macro...)
+ *
+ * The keymap must use &ak_A instead of &kp A etc.
+ */
+        ak_A: ak_A {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp A>;
+
+            akA_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(A)>; };
+        };
+        ak_B: ak_B {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp B>;
+
+            akB_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(B)>; };
+        };
+        ak_C: ak_C {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp C>;
+
+            akC_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(C)>; };
+        };
+        ak_D: ak_D {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp D>;
+
+            akD_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(D)>; };
+        };
+        ak_E: ak_E {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp E>;
+
+            akE_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(E)>; };
+        };
+        ak_F: ak_F {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp F>;
+
+            akF_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(F)>; };
+            // akF_t_v { trigger-keys = <D>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp V>; };
+        };
+        ak_G: ak_G {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp G>;
+
+            akG_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(G)>; };
+        };
+        ak_H: ak_H {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp H>;
+
+            akH_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(H)>; };
+        };
+        ak_I: ak_I {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp I>;
+
+            akI_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(I)>; };
+        };
+        ak_J: ak_J {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp J>;
+
+            akJ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(J)>; };
+        };
+        ak_K: ak_K {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp K>;
+
+            akK_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(K)>; };
+        };
+        ak_L: ak_L {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp L>;
+
+            akL_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(L)>; };
+        };
+        ak_M: ak_M {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp M>;
+
+            akM_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(M)>; };
+        };
+        ak_N: ak_N {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp N>;
+
+            akN_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(N)>; };
+            // akN_t_ion { trigger-keys = <T>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp I &kp O &kp N>; };
+        };
+        ak_O: ak_O {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp O>;
+
+            akO_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(O)>; };
+        };
+        ak_P: ak_P {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp P>;
+
+            akP_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(P)>; };
+        };
+        ak_Q: ak_Q {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp Q>;
+
+            akQ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Q)>; };
+        };
+        ak_R: ak_R {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp R>;
+
+            akR_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(R)>; };
+        };
+        ak_S: ak_S {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp S>;
+
+            akS_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(S)>; };
+        };
+        ak_T: ak_T {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp T>;
+
+            akT_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(T)>; };
+        };
+        ak_U: ak_U {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp U>;
+
+            akU_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(U)>; };
+        };
+        ak_V: ak_V {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp V>;
+
+            akV_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(V)>; };
+        };
+        ak_W: ak_W {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp W>;
+
+            akW_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(W)>; };
+        };
+        ak_X: ak_X {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp X>;
+
+            akX_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(X)>; };
+        };
+        ak_Y: ak_Y {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp Y>;
+
+            akY_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Y)>; };
+        };
+        ak_Z: ak_Z {
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp Z>;
+
+            akZ_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(Z)>; };
+        };
+
+/*
+        ak_CMMA: ak_CMMA { // double-tap comma = caps_word
+            compatible = "zmk,behavior-adaptive-key";
+            #binding-cells = <0>;
+            bindings = <&kp CMMA>;
+            ak_CMMA_cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &caps_word>; };
+        };
+*/

--- a/config/adaptive-keys.h
+++ b/config/adaptive-keys.h
@@ -18,6 +18,8 @@
             bindings = <&kp A>;
 
             akA_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(A)>; strict-modifiers; };
+            // qa -> qua:
+            akQA_t_ua { trigger-keys = <Q>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp U &kp A>; strict-modifiers; };
         };
         ak_B: ak_B {
             compatible = "zmk,behavior-adaptive-key";
@@ -46,6 +48,8 @@
             bindings = <&kp E>;
 
             akE_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(E)>; strict-modifiers; };
+            // qe -> que
+            akQE_t_ue { trigger-keys = <Q>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp U &kp E>; strict-modifiers; };
         };
         ak_F: ak_F {
             compatible = "zmk,behavior-adaptive-key";
@@ -75,6 +79,8 @@
             bindings = <&kp I>;
 
             akI_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(I)>; strict-modifiers; };
+            // qi -> qui
+            akQI_t_ui { trigger-keys = <Q>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp U &kp I>; strict-modifiers; };
         };
         ak_J: ak_J {
             compatible = "zmk,behavior-adaptive-key";
@@ -118,6 +124,8 @@
             bindings = <&kp O>;
 
             akO_Cap { trigger-keys = <CMMA>; max-prior-idle-ms = <my_cc_term>; bindings = <&kp BSPC &kp LS(O)>; strict-modifiers; };
+            // qo -> quo
+            akQO_t_uo { trigger-keys = <Q>; max-prior-idle-ms = <my_ak_term>; bindings = <&kp U &kp O>; strict-modifiers; };
         };
         ak_P: ak_P {
             compatible = "zmk,behavior-adaptive-key";

--- a/config/tc36k.keymap
+++ b/config/tc36k.keymap
@@ -23,6 +23,8 @@
 #define NAGINATA 1
 #define NUM_NAV 2
 
+#define my_cc_term 1400 // CommaCap trigger time window
+
 / {
     macros {
         // To switch to Japanese mode, this sends what Karabiner-Elements sees
@@ -80,6 +82,8 @@
             keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
         };
 
+#include "adaptive-keys.h"
+
     };
 };
 
@@ -90,10 +94,10 @@
         default_layer {
             display-name = "HD Promethium";
             bindings = <
-                &kp ESCAPE &kp P  &kp G    &kp M   &kp X    &kp SLASH &kp DOT   &xquote &kp MINUS &kp EQUAL
-                &kp S      &kp N  &kp T    &kp H   &kp K    &kp COMMA &kp A     &kp E   &kp I     &kp C
-                &kp B      &kp F  &kp D    &kp L   &kp J    &kp SEMI  &kp U     &kp O   &kp Y     &kp W
-                                  &kp LGUI &kp R   &kp BSPC &kp LSHFT &kp SPACE &mo NUM_NAV
+                &kp ESCAPE &ak_P  &ak_G    &ak_M   &ak_X    &kp SLASH   &kp DOT   &xquote &kp MINUS &kp EQUAL
+                &ak_S      &ak_N  &ak_T    &ak_H   &ak_K    &kp COMMA   &ak_A     &ak_E   &ak_I     &ak_C
+                &ak_B      &ak_F  &ak_D    &ak_L   &ak_J    &kp SEMI    &ak_U     &ak_O   &ak_Y     &ak_W
+                                  &kp LGUI &kp R   &kp BSPC &kp LSHFT   &kp SPACE &mo NUM_NAV
             >;
         };
 
@@ -223,19 +227,19 @@
 
         // 2-key horizontal combos for rare letters
         q_combo {
-            bindings = <&kp Q>;
+            bindings = <&ak_Q>;
             key-positions = <LT1 LT2>;
             layers = <DEFAULT>;
         };
 
         z_combo {
-            bindings = <&kp Z>;
+            bindings = <&ak_Z>;
             key-positions = <RT2 RT3>;
             layers = <DEFAULT>;
         };
 
         v_combo {
-            bindings = <&kp V>;
+            bindings = <&ak_V>;
             key-positions = <LT2 LT3>;
             layers = <DEFAULT>;
         };

--- a/config/tc36k.keymap
+++ b/config/tc36k.keymap
@@ -23,6 +23,7 @@
 #define NAGINATA 1
 #define NUM_NAV 2
 
+#define my_ak_term 350 // behavior-adaptive-key trigger time window
 #define my_cc_term 1400 // CommaCap trigger time window
 
 / {

--- a/config/west.yml
+++ b/config/west.yml
@@ -19,6 +19,9 @@ manifest:
     - name: zmk-keyboard-graph-theory
       remote: peterjc
       revision: main
+    - name: zmk-adaptive-key
+      remote: urob
+      revision: main # set to same as ZMK version above
     - name: zmk-helpers
       remote: urob
     - name: zmk-naginata

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -184,7 +184,35 @@ parse_config:
     '&kp MINUS': {'t': '-', 's': '_', 'type': 'medium-low'}
     '&kp EQUAL': {'t': '=', 's': '+', 'type': 'low'}
     '&kp SPACE': {'t': '⎵', 'type': 'high'}
-     # These are the Naginata Style keys for typing in Japanese using kana:
+    # Again for adaptive key variants:
+    '&ak_Q': {'t': 'Q', 'type': 'low'}
+    '&ak_W': {'t': 'W', 'type': 'medium'}
+    '&ak_E': {'t': 'E', 'type': 'high'}
+    '&ak_R': {'t': 'R', 'type': 'high'}
+    '&ak_T': {'t': 'T', 'type': 'high'}
+    '&ak_Y': {'t': 'Y', 'type': 'medium'}
+    '&ak_U': {'t': 'U', 'type': 'medium-high'}
+    '&ak_I': {'t': 'I', 'type': 'high'}
+    '&ak_O': {'t': 'O', 'type': 'high'}
+    '&ak_P': {'t': 'P', 'type': 'medium-low'}
+    '&ak_A': {'t': 'A', 'type': 'high'}
+    '&ak_S': {'t': 'S', 'type': 'high'}
+    '&ak_D': {'t': 'D', 'type': 'medium-high'}
+    '&ak_F': {'t': 'F', 'type': 'medium'}
+    '&ak_G': {'t': 'G', 'type': 'medium'}
+    '&ak_H': {'t': 'H', 'type': 'high'}
+    '&ak_J': {'t': 'J', 'type': 'low'}
+    '&ak_K': {'t': 'K', 'type': 'low'}
+    '&ak_L': {'t': 'L', 'type': 'medium-high'}
+    '&ak_Z': {'t': 'Z', 'type': 'low'}
+    '&ak_X': {'t': 'X', 'type': 'low'}
+    '&ak_C': {'t': 'C', 'type': 'medium'}
+    '&ak_V': {'t': 'V', 'type': 'low'}
+    '&ak_B': {'t': 'B', 'type': 'medium-low'}
+    '&ak_N': {'t': 'N', 'type': 'high'}
+    '&ak_M': {'t': 'M', 'type': 'medium'}
+    '&ak_COMMA': {'t': ',', 's': '<', 'type': 'medium-low'}
+    # These are the Naginata Style keys for typing in Japanese using kana:
     '&ng Q': {'t': '⎋', 'h': 'Small-kana'}
     '&ng W': {'left': 'き', 'right': 'ぬ'}
     '&ng E': {'left': 'て', 'right': 'り'}


### PR DESCRIPTION
Comma almost never preceeds a letter (usually followed by space, or a number).
Treat comma then letter as meaning capital letter (sends backspace then shifted
letter) using urob's behavior-adaptive-key module https://github.com/urob/zmk-adaptive-key/

The keymap must use `&ak_A` instead of `&kp A` etc.

See:
* https://github.com/moutis/zmk-config
* https://www.reddit.com/r/KeyboardLayouts/comments/1bnows4/analysis_oneshot_shift_as_a_letter/
* https://www.reddit.com/r/KeyboardLayouts/comments/1cc2yri/oneshot_shift_via_adaptive_keys/
* https://www.reddit.com/r/ErgoMechKeyboards/comments/1n201er/comment/nb2tg1s/

May want to think about the comma placement but currently (and with #7) it is on the right index finger ~ and that shift is often assigned to the index finger with HRM which matches.

Worth looking at Caps Word too (eg via double comma), should be useful in Japanese Romaji mode for a Katakana word?