### PR TITLE
One key per thumb (just two thumb keys total)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ My base layer is the inverted [Hands Down Promethium
 layout](https://www.reddit.com/r/KeyboardLayouts/comments/1g66ivi/hands_down_promethium_snth_meets_hd_silverengram/)
 with my personal modifications ("Pico Mod") intended to help with some readline shortcuts
 (horizontal pair `B`/`F` for back/forward, vertical pair `P`/`N` for previous/next).
-It also has matching `B` (bottom left) and `W` (bottom right) for back to start of word, and
-forward to start of next word in Vim or Helix.
-Most of the symbols are 2-key vertical combos, the brackets are 2-key horizontal combos
-(open on the left hand, close on the right). There is a single combined numbers and navigation
-layer accessed by holding the right thumb.
+It also has matching `B` (bottom left) and `W` (bottom right) for back to start
+of word, and forward to start of next word in Vim or Helix.
+Most of the symbols are 2-key vertical combos, the brackets are 2-key horizontal
+combos (open on the left hand, close on the right).
+
 I wanted to be able to use this on my laptop too - achieved with [custom Karabiner-Elements
 rules](https://codeberg.org/peterjc/kana-chording-ke/src/branch/main/hands-down-on-jis-macbook)
 (see this [blog post](https://blastedbio.blogspot.com/2025/05/what-have-you-done-to-your-keyboard.html)).
@@ -32,21 +32,23 @@ currently at [v17](https://oookaworks.seesaa.net/article/519707171.html).
 I made minor changes so that Qwerty `Q` is now Escape on tap, small on hold, and
 added shift-space on a thumb for kanji selection without needing editing layers.
 Due to my brackets combos clashing with the default way to switch Japanese mode
-and the Naginata layer on and off, those are Qwerty `D`+`G` (labelled 'ABC' in
-the image) and Qwerty `H`+`K` instead (labelled 'かな'). This layout uses a *lot*
+and the Naginata layer on and off, those are Qwerty `D`+`G` (labeled 'ABC' in
+the image) and Qwerty `H`+`K` instead (labeled 'かな'). This layout uses a *lot*
 of chording, but these are not defined as ZMK combos, and so are not drawn here.
 
 The third and final layer is a combined numbers and navigation layer. The right
 hand has navigation keys including an inverted-tee set of cursors at the Qwerty
 JKIL position inspired by [Dreymar's Extend layer](https://dreymar.colemak.org/layers-extend.html).
-The left hand has a numberpad, with 123 at the top like a mobile phone (since
-in a traditionad keyboard 123 are about there).
+The left hand has a number-pad, with 123 at the top like a mobile phone (since
+in a traditional keyboard 123 are about there).
 
+I am trying *Magic Comma Shift* whereby typing comma then a letter will give the
+capital version of the letter - but typing comma and space just works as usual.
 
 ## Split 3x5_3 aka 33333+3 Layout with 36 keys
 
 The QMK project uses the term `split_3x5_3` for one of their standard community
-layout names for the most common 36 key layouts. This means a symmetrical split
+layout names for the most common 36 key layout. This means a symmetrical split
 layout where each hand has three rows and five columns (the index finger gets
 an extra inner column), plus three thumb keys.
 
@@ -60,7 +62,7 @@ for even smaller keyboards - see below).
 ### Gamma Omega TC36K
 
 The ZMK keymap in file [tc36k.keymap](config/tc36k.keymap) is the split 3x5_3
-layout described above (without the bluetooth combos) for the self-built
+layout described above (without the Bluetooth combos) for the self-built
 [Gamma Omega TC36K](https://github.com/unspecworks/gamma-omega/tree/main/tc36k).
 This is a single PCB no-diode variant of the Gamma Omega where [I designed the
 wiring and PCB](https://astrobeano.blogspot.com/2025/08/my-first-self-built-computer-keyboard.html).
@@ -151,9 +153,9 @@ one of the layouts supported by the
 [Visorbearer](https://github.com/carrefinho/visorbearer).
 
 This means dropping backspace of the left thumb (leaving just the Naginata Style
-backspace on the index finger), and the dedicated shift on the right thumb (and
-holding the `R` left thumb for shift). Capital `R` is therefore on the left-thumb
-on the numbers and navigation layer.
+backspace on the index finger), and the dedicated shift on the right thumb (note
+holding the `R` left thumb gives shift). Capital `R` is available with *Magic
+Comma Shift* only.
 
 ![Keymap image](keymap-drawer/bivvy16d.svg)
 

--- a/README.md
+++ b/README.md
@@ -122,15 +122,6 @@ redundant with a navigation layer - but the remaining inner column keys are
 vertically swapped to ensure the ya-combos are comfortable (see this
 [blog post](https://astrobeano.blogspot.com/2026/03/naginata-style-update.html)).
 
-### Bivvy16D
-
-The ZMK keymap in file [bivvy16d.keymap](config/bivvy16D.keymap) uses the split
-33332+2 layout described here (32 keys) plus navigation and cursors on the two
-5-way navigation buttons.
-
-The Bivvy16D has 14-key roll-over excluding the navigation buttons, 4-key roll
-over when they are included (per hand).
-
 ### Bivouac34
 
 The ZMK keymap in file [bivouac34.keymap](config/bivouac34.keymap) is the layout
@@ -138,15 +129,6 @@ shown above, a split 33332+2 layout (32 keys only). The keyboard also supports a
 34 key 33332+3 layout (which I am not using).
 
 Like the Hesse (above), this has only 4-key roll-over.
-
-### Goldilocks32
-
-The ZMK keymap in file [goldilocks32.keymap](config/goldilocks32.keymap) uses the same
-split 33332+2 layout described above (32 keys) plus cursors and enter on the 5-way
-navigation button.
-
-The Goldilocks32 has 6-key roll-over excluding the navigation button, 4-key roll
-over when that is included.
 
 ## Split 23332+2 Layout with 30 keys
 
@@ -168,9 +150,30 @@ keyboards](https://github.com/jcmkk3/awesome-hummingbirds) - for example this is
 one of the layouts supported by the
 [Visorbearer](https://github.com/carrefinho/visorbearer).
 
-This would mean dropping backspace of the left thumb (leaving just the Naginata
-Style backspace on the index finger), and the dedicated shift on the right thumb.
-That seems possible...
+This means dropping backspace of the left thumb (leaving just the Naginata Style
+backspace on the index finger), and the dedicated shift on the right thumb (and
+holding the `R` left thumb for shift). Capital `R` is therefore on the left-thumb
+on the numbers and navigation layer.
+
+![Keymap image](keymap-drawer/bivvy16d.svg)
+
+### Bivvy16D
+
+The ZMK keymap in file [bivvy16d.keymap](config/bivvy16D.keymap) is the 30 key
+layout above, plus navigation and cursors on the two 5-way navigation buttons.
+
+The Bivvy16D has 14-key roll-over excluding the navigation buttons, 4-key roll
+over when they are included (per hand). It can be built like this with 30 keys,
+or with two keys per thumb for 32 keys.
+
+### Goldilocks32
+
+The ZMK keymap in file [goldilocks32.keymap](config/goldilocks32.keymap) uses this
+30 key layout, plus cursors and enter on the 5-way navigation button.
+
+The Goldilocks32 has 6-key roll-over excluding the navigation button, 4-key roll
+over when that is included. It can be built like this with 30 keys, or with two
+keys per thumb for 32 keys.
 
 
 ## Slump layouts - Split 44332+2

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -141,7 +141,7 @@
             // (Staying with default limit of 32 definitions)
         };
 
-        hpmt_qt: hold_preferred_mod_tap_qt {
+        hpmt: hold_preferred_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "hold-preferred";
@@ -149,15 +149,7 @@
             quick-tap-ms = <175>;
             bindings = <&kp>, <&kp>;
         };
-        hpmt: hold_preferred_mod_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "hold-preferred";
-            tapping-term-ms = <300>;
-            bindings = <&kp>, <&kp>;
-        };
-
-        bmt_qt: balanced_mod_tap_qt {
+        bmt: balanced_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
@@ -165,15 +157,7 @@
             quick-tap-ms = <250>;
             bindings = <&kp>, <&kp>;
         };
-        bmt: balanced_mod_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "balanced";
-            tapping-term-ms = <300>;
-            bindings = <&kp>, <&kp>;
-        };
-
-        tpmt_qt: tap_preferred_mod_tap_qt {
+        tpmt: tap_preferred_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
@@ -181,27 +165,12 @@
             quick-tap-ms = <250>;
             bindings = <&kp>, <&kp>;
         };
-        tpmt: tap_preferred_mod_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "tap-preferred";
-            tapping-term-ms = <300>;
-            bindings = <&kp>, <&kp>;
-        };
-
-        blt_qt: balanced_layer_tap_qt {
+        blt: balanced_layer_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <300>;
             quick-tap-ms = <250>;
-            bindings = <&mo>, <&kp>;
-        };
-        blt: balanced_layer_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "balanced";
-            tapping-term-ms = <300>;
             bindings = <&mo>, <&kp>;
         };
 
@@ -261,7 +230,7 @@
                 &kp ESCAPE, &kp P, &kp G,   &kp M,        &kp X,    &kp SLASH,   &kp BSPC,           &xquote, &kp MINUS, &kp EQUAL, \
                 &kp S,      &kp N, &kp T,   &kp H,        &kp K,    &dot_colon,  &kp A,              &kp E,   &kp I,     &kp C,  \
                 &kp B,      &kp F, &kp D,   &kp L,        &kp J,    &comma_semi, &kp U,              &kp O,   &kp Y,     &kp W,  \
-                                   &kp TAB, &blt_qt NUM_NAV R, &hpmt_qt LSHFT BSPC, &hpmt_qt RSHFT BSPC, &bmt RSHFT SPACE, &mo NUM_NAV \
+                                   &kp TAB, &bmt LSHFT R, &kp BSPC, &kp RSHFT,   &blt NUM_NAV SPACE, &mo NUM_NAV \
             )>;
         };
 

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -261,7 +261,7 @@
                 &kp ESCAPE, &kp P, &kp G,   &kp M,        &kp X,    &kp SLASH,   &kp BSPC,           &xquote, &kp MINUS, &kp EQUAL, \
                 &kp S,      &kp N, &kp T,   &kp H,        &kp K,    &dot_colon,  &kp A,              &kp E,   &kp I,     &kp C,  \
                 &kp B,      &kp F, &kp D,   &kp L,        &kp J,    &comma_semi, &kp U,              &kp O,   &kp Y,     &kp W,  \
-                                   &kp TAB, &bmt_qt LSHFT R, &hpmt_qt LSHFT BSPC, &hpmt_qt RSHFT BSPC, &blt_qt NUM_NAV SPACE, &mo NUM_NAV \
+                                   &kp TAB, &blt_qt NUM_NAV R, &hpmt_qt LSHFT BSPC, &hpmt_qt RSHFT BSPC, &bmt RSHFT SPACE, &mo NUM_NAV \
             )>;
         };
 
@@ -301,7 +301,7 @@
                 &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_MINUS, &kp ESCAPE, &kp BSPC,     &kp UP,     &trans,        &kp C_PLAY_PAUSE, \
                 &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp DOT,      &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,     &kp C_VOLUME_UP, \
                 &kp KP_PLUS,     &kp N7, &kp N8, &kp N9, &kp N0,       &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT), &kp C_VOLUME_DOWN, \
-                                         &trans, &hpmt LSHFT RS(R), &trans, &trans, &trans, &trans \
+                                         &trans, &hpmt LSHFT RS(R), &trans, &trans, &hpmt RSHFT LS(SPACE), &trans \
                 )>;
         };
 

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -251,7 +251,7 @@
                 &ng Q, &ng W, &ng E,   &ng R,     &ng B,    &ng N,     &ng U,                 &ng I,     &ng O,      &ng P, \
                 &ng A, &ng S, &ng D,   &ng F,     &ng G,    &ng H,     &ng J,                 &ng K,     &ng L,      &ng SEMI, \
                 &ng Z, &ng X, &ng C,   &ng V,     &ng T,    &ng Y,     &ng M,                 &ng COMMA, &ng DOT,    &ng SLASH, \
-                              &kp TAB, &ng ENTER, &kp BSPC, &ng SPACE, &lt NUM_NAV LS(SPACE), &mo NUM_NAV \
+                              &kp TAB, &ng SPACE, &kp BSPC, &ng ENTER, &lt NUM_NAV LS(SPACE), &mo NUM_NAV \
                 )>;
         };
 #else
@@ -262,7 +262,7 @@
                 &ng Q, &ng W, &ng E,   &ng R,     &ng B,    &ng N,     &ng U,                 &ng I,     &ng O,      &ng P, \
                 &ng A, &ng S, &ng D,   &ng F,     &ng G,    &ng H,     &ng J,                 &ng K,     &ng L,      &ng SEMI, \
                 &ng Z, &ng X, &ng C,   &ng V,     &ng T,    &ng Y,     &ng M,                 &ng COMMA, &ng DOT,    &ng SLASH, \
-                              &kp TAB, &ng ENTER, &kp BSPC, &ng SPACE, &lt NUM_NAV LS(SPACE), &mo NUM_NAV \
+                              &kp TAB, &ng SPACE, &kp BSPC, &ng ENTER, &lt NUM_NAV LS(SPACE), &mo NUM_NAV \
                 )>;
         };
 #endif

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -270,11 +270,11 @@
         num_nav_layer {
             display-name = "Num + Nav";
             bindings = <LAYER_FROM36( \
-                &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_EQUAL, &kp ESCAPE, &kp HOME,     &kp UP,     &kp END,       &kp C_PLAY_PAUSE, \
-                &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,     &kp C_VOLUME_UP, \
-                &kp DOT,         &kp N7, &kp N8, &kp N9, &kp KP_MINUS, &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT), &kp C_VOLUME_DOWN, \
-                                         &trans, &hpmt LSHFT N0, &trans, &trans, &trans, &trans \
-            )>;
+                &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_MINUS, &kp ESCAPE, &kp BSPC,     &kp UP,     &trans,        &kp C_PLAY_PAUSE, \
+                &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp DOT,      &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,     &kp C_VOLUME_UP, \
+                &kp KP_PLUS,     &kp N7, &kp N8, &kp N9, &kp N0,       &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT), &kp C_VOLUME_DOWN, \
+                                         &trans, &hpmt LSHFT RS(R), &trans, &trans, &trans, &trans \
+                )>;
         };
 
         // Empty layers for ZMK Studio:

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -267,9 +267,9 @@
         num_nav_layer {
             display-name = "Num + Nav";
             bindings = <LAYER_FROM36( \
-                &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_EQUAL, &kp ESCAPE, &kp HOME,     &kp UP,     &kp END,       &kp C_PLAY_PAUSE, \
-                &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,     &kp C_VOLUME_UP, \
-                &kp DOT,         &kp N7, &kp N8, &kp N9, &kp KP_MINUS, &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT), &kp C_VOLUME_DOWN, \
+                &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_EQUAL, &kp ESCAPE, &kp BSPC,     &kp UP,     &kp UNDERSCORE, &kp C_PLAY_PAUSE, \
+                &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,      &kp C_VOLUME_UP, \
+                &kp DOT,         &kp N7, &kp N8, &kp N9, &kp KP_MINUS, &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT),  &kp C_VOLUME_DOWN, \
                                          &trans, &hpmt LSHFT N0, &trans, &trans, &trans, &trans \
             )>;
         };

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -298,11 +298,11 @@
         num_nav_layer {
             display-name = "Num + Nav";
             bindings = <LAYER_FROM36( \
-                &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_MINUS, &kp ESCAPE, &kp BSPC,     &kp UP,     &trans,        &kp C_PLAY_PAUSE, \
-                &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp DOT,      &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,     &kp C_VOLUME_UP, \
-                &kp KP_PLUS,     &kp N7, &kp N8, &kp N9, &kp N0,       &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT), &kp C_VOLUME_DOWN, \
-                                         &trans, &hpmt LSHFT RS(R), &trans, &trans, &hpmt RSHFT LS(SPACE), &trans \
-                )>;
+                &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_EQUAL, &kp ESCAPE, &kp HOME,     &kp UP,     &kp END,       &kp C_PLAY_PAUSE, \
+                &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,     &kp C_VOLUME_UP, \
+                &kp DOT,         &kp N7, &kp N8, &kp N9, &kp KP_MINUS, &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT), &kp C_VOLUME_DOWN, \
+                                         &trans, &hpmt LSHFT N0, &trans, &trans, &trans, &trans \
+            )>;
         };
 
         // Empty layers for ZMK Studio:

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -233,7 +233,7 @@
                 &kp ESCAPE, &kp P, &kp G,   &kp M,        &kp X,    &kp SLASH,   &kp BSPC,           &xquote, &kp MINUS, &kp EQUAL, \
                 &kp S,      &kp N, &kp T,   &kp H,        &kp K,    &dot_colon,  &kp A,              &kp E,   &kp I,     &kp C,  \
                 &kp B,      &kp F, &kp D,   &kp L,        &kp J,    &comma_semi, &kp U,              &kp O,   &kp Y,     &kp W,  \
-                                   &kp TAB, &bmt LSHFT R, &kp BSPC, &kp RSHFT,   &blt NUM_NAV SPACE, &mo NUM_NAV \
+                                   &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC, &hpmt RSHFT BSPC, &blt NUM_NAV SPACE, &mo NUM_NAV \
             )>;
         };
 

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -141,7 +141,7 @@
             // (Staying with default limit of 32 definitions)
         };
 
-        hpmt: hold_preferred_mod_tap {
+        hpmt_qt: hold_preferred_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "hold-preferred";
@@ -149,8 +149,15 @@
             quick-tap-ms = <175>;
             bindings = <&kp>, <&kp>;
         };
+        hpmt: hold_preferred_mod_tap {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "hold-preferred";
+            tapping-term-ms = <300>;
+            bindings = <&kp>, <&kp>;
+        };
 
-        bmt: balanced_mod_tap {
+        bmt_qt: balanced_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
@@ -158,8 +165,15 @@
             quick-tap-ms = <250>;
             bindings = <&kp>, <&kp>;
         };
+        bmt: balanced_mod_tap {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <300>;
+            bindings = <&kp>, <&kp>;
+        };
 
-        tpmt: tap_preferred_mod_tap {
+        tpmt_qt: tap_preferred_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
@@ -167,13 +181,27 @@
             quick-tap-ms = <250>;
             bindings = <&kp>, <&kp>;
         };
+        tpmt: tap_preferred_mod_tap {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "tap-preferred";
+            tapping-term-ms = <300>;
+            bindings = <&kp>, <&kp>;
+        };
 
-        blt: balanced_layer_tap {
+        blt_qt: balanced_layer_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <300>;
             quick-tap-ms = <250>;
+            bindings = <&mo>, <&kp>;
+        };
+        blt: balanced_layer_tap {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <300>;
             bindings = <&mo>, <&kp>;
         };
 
@@ -233,7 +261,7 @@
                 &kp ESCAPE, &kp P, &kp G,   &kp M,        &kp X,    &kp SLASH,   &kp BSPC,           &xquote, &kp MINUS, &kp EQUAL, \
                 &kp S,      &kp N, &kp T,   &kp H,        &kp K,    &dot_colon,  &kp A,              &kp E,   &kp I,     &kp C,  \
                 &kp B,      &kp F, &kp D,   &kp L,        &kp J,    &comma_semi, &kp U,              &kp O,   &kp Y,     &kp W,  \
-                                   &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC, &hpmt RSHFT BSPC, &blt NUM_NAV SPACE, &mo NUM_NAV \
+                                   &kp TAB, &bmt_qt LSHFT R, &hpmt_qt LSHFT BSPC, &hpmt_qt RSHFT BSPC, &blt_qt NUM_NAV SPACE, &mo NUM_NAV \
             )>;
         };
 

--- a/config/bivvy16d.keymap
+++ b/config/bivvy16d.keymap
@@ -1,4 +1,4 @@
-/*                              42 KEY MATRIX / LAYOUT MAPPING
+/*                       32 (or 42 inc nav) KEY MATRIX / LAYOUT MAPPING
 
 Here on most layers I am treating the inner keys as lower down (LM0, LB0, RM0, and RB0), as drawn here:
 
@@ -21,8 +21,9 @@ with the tucked thumbs LH1 and RH1 too:
   ╰───────────────╮ 40 │ 41  ╭──────────────╯ ╰───────────────╮ LH0 │ RH0 ╭───────────────╯
                   ╰────┴─────╯                                ╰─────┴─────╯
 
-And there are the two five-way buttons too (keys 30 to 39), which is why the splayed thumbs
-LH0 and RH0 are keys 40 and 41. */
+And there are the two five-way buttons too (keys 30 to 39), which is why the optional splayed
+thumbs LH0 and RH0 are keys 40 and 41.
+*/
 
 #pragma once
 
@@ -62,11 +63,16 @@ LH0 and RH0 are keys 40 and 41. */
 #define RB3 28
 #define RB4 29
 
-#define LH0 40  // left thumb keys
-#define LH1 24
+// If using all four thumbs:
+// #define LH0 40  // left thumb keys
+// #define LH1 24
+// 
+// #define RH0 41  // right thumb keys
+// #define RH1 25
 
-#define RH0 41  // right thumb keys
-#define RH1 25
+// Using just one key per thumb
+#define LH1 24  // left thumb keys
+#define RH1 25  // right thumb keys
 
 // Drop top row middle corners (Qwerty T and Y, or LT0 and RT0, or k04 and k05)
 // and the most tucked thumbs (LH2 and RH2 in ZMK-helpers terms, k30 and k35).
@@ -82,7 +88,7 @@ LH0 and RH0 are keys 40 and 41. */
     k10  k11  k12  k13  k24  k25  k16  k17  k18  k19  \
     k20  k21  k22  k23  k31  k34  k26  k27  k28  k29  \
     &kp PG_DN &kp HOME &kp KP_ENTER &kp END &kp PG_UP &kp UP &kp LEFT &kp ENTER &kp RIGHT &kp DOWN  \
-    k32  k33
+//    k32  k33
 
 // This drops Qwerty B and N (k24 and k25), which in my Naginata where the
 // inner columns are vertically inverted are the reduntant left/right arrows.
@@ -97,9 +103,14 @@ LH0 and RH0 are keys 40 and 41. */
     k10  k11  k12  k13  k14  k15  k16  k17  k18  k19  \
     k20  k21  k22  k23  k31  k34  k26  k27  k28  k29  \
     &kp PG_DN &kp HOME &kp KP_ENTER &kp END &kp PG_UP &kp UP &kp LEFT &kp ENTER &kp RIGHT &kp DOWN  \
-    k32  k33
-
-
+//   k32  k33
 
 
 #include "3x5_3.dtsi"
+
+/ {
+    chosen {
+        zmk,physical-layout = &bivvy16d_L15_R15_layout;
+        // Other chosen items
+    };
+};

--- a/config/bivvy16d.keymap
+++ b/config/bivvy16d.keymap
@@ -66,7 +66,7 @@ thumbs LH0 and RH0 are keys 40 and 41.
 // If using all four thumbs:
 // #define LH0 40  // left thumb keys
 // #define LH1 24
-// 
+//
 // #define RH0 41  // right thumb keys
 // #define RH1 25
 

--- a/config/goldilocks32.keymap
+++ b/config/goldilocks32.keymap
@@ -73,10 +73,14 @@ Same, just without LH0 and RH0 aka keys 35 and 36. */
 #define RB4 29
 
 // With four thumb keys in 32-key layout
-#define LH0 35  // left thumb keys
-#define LH1 24
-#define RH0 36  // right thumb keys
-#define RH1 25
+// #define LH0 35  // left thumb keys
+// #define LH1 24
+// #define RH0 36  // right thumb keys
+// #define RH1 25
+
+// With just two thumb keys in 30-key layout
+#define LH1 24  // left thumb key
+#define RH1 25  // right thumb key
 
 // Drop top row middle corners (Qwerty T and Y, or LT0 and RT0, or k04 and k05)
 // moving the rest of those columns up.
@@ -90,7 +94,7 @@ Same, just without LH0 and RH0 aka keys 35 and 36. */
     k10  k11  k12  k13  k24  k25  k16  k17  k18  k19  \
     k20  k21  k22  k23  k31  k34  k26  k27  k28  k29  \
     &kp UP &kp LEFT &kp ENTER &kp RIGHT &kp DOWN  \
-                        k32  k33
+//                        k32  k33
 
 // This drops Qwerty B and N (k24 and k25), which in my Naginata where the
 // inner columns are vertically inverted are the reduntant left/right arrows.
@@ -105,13 +109,13 @@ Same, just without LH0 and RH0 aka keys 35 and 36. */
     k10  k11  k12  k13  k14  k15  k16  k17  k18  k19  \
     k20  k21  k22  k23  k31  k34  k26  k27  k28  k29  \
     &kp UP &kp LEFT &kp ENTER &kp RIGHT &kp DOWN  \
-                        k32  k33
+//                        k32  k33
 
 #include "3x5_3.dtsi"
 
 / {
     chosen {
-        zmk,physical-layout = &physical_layout32;
+        zmk,physical-layout = &physical_layout30;
         // Other chosen items
     };
 };

--- a/config/slump52.keymap
+++ b/config/slump52.keymap
@@ -67,10 +67,10 @@ Using pinky stagger here, and treating the thumbs as five thumb keys with no Qwe
     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, \
               k30, k31, k32, k33, k34, k35            \
 ) \
-    k00  k00  k01  k02  k03  k14           k15  k06  k07  k08  k09 &kp KP_MULTIPLY &kp N7 &kp N8 &kp N9\
-         k00  k11  k12  k13  k24           k25  k16  k17  k18  k05                 &kp N4 &kp N5 &kp N6 \
-         k10  k21  k22  k23  k31           k34  k26  k27  k28  k19                 &kp N1 &kp N2 &kp N3 \
-         k20                 k32 &kp LSHFT k33 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET 
+    k00  k00  k01  k02  k03  k14     k15  k06  k07  k08  k09 &kp KP_MULTIPLY &kp N7 &kp N8 &kp N9\
+         k00  k11  k12  k13  k24     k25  k16  k17  k18  k05                 &kp N4 &kp N5 &kp N6 \
+         k10  k21  k22  k23  k31     k34  k26  k27  k28  k19                 &kp N1 &kp N2 &kp N3 \
+         k20                 k31 k32 k34 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET 
 
 // This drops Qwerty B and N (k24 and k25), which in my Naginata where the
 // inner columns are vertically inverted are the reduntant left/right arrows.
@@ -80,9 +80,9 @@ Using pinky stagger here, and treating the thumbs as five thumb keys with no Qwe
     k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, \
               k30, k31, k32, k33, k34, k35            \
 ) \
-    k00  k00  k01  k02  k03  k04           k05  k06  k07  k08  k09 k09 &kp N7 &kp N8 &kp N9\
-         k00  k11  k12  k13  k14           k15  k16  k17  k18  k09     &kp N4 &kp N5 &kp N6 \
-         k10  k21  k22  k23  k31           k34  k26  k27  k28  k19     &kp N1 &kp N2 &kp N3 \
-         k20                 k32 &kp LSHFT k33 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET 
+    k00  k00  k01  k02  k03  k04     k05  k06  k07  k08  k09 k09 &kp N7 &kp N8 &kp N9\
+         k00  k11  k12  k13  k14     k15  k16  k17  k18  k09     &kp N4 &kp N5 &kp N6 \
+         k10  k21  k22  k23  k31     k34  k26  k27  k28  k19     &kp N1 &kp N2 &kp N3 \
+         k20                 k31 k32 k34 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET 
 
 #include "3x5_3.dtsi"

--- a/config/slump52.keymap
+++ b/config/slump52.keymap
@@ -70,7 +70,7 @@ Using pinky stagger here, and treating the thumbs as five thumb keys with no Qwe
     k00  k00  k01  k02  k03  k14     k15  k06  k07  k08  k09 &kp KP_MULTIPLY &kp N7 &kp N8 &kp N9\
          k00  k11  k12  k13  k24     k25  k16  k17  k18  k05                 &kp N4 &kp N5 &kp N6 \
          k10  k21  k22  k23  k31     k34  k26  k27  k28  k19                 &kp N1 &kp N2 &kp N3 \
-         k20                 k31 k32 k34 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET 
+         k20                 k31 k32 k34 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET
 
 // This drops Qwerty B and N (k24 and k25), which in my Naginata where the
 // inner columns are vertically inverted are the reduntant left/right arrows.
@@ -83,6 +83,6 @@ Using pinky stagger here, and treating the thumbs as five thumb keys with no Qwe
     k00  k00  k01  k02  k03  k04     k05  k06  k07  k08  k09 k09 &kp N7 &kp N8 &kp N9\
          k00  k11  k12  k13  k14     k15  k16  k17  k18  k09     &kp N4 &kp N5 &kp N6 \
          k10  k21  k22  k23  k31     k34  k26  k27  k28  k19     &kp N1 &kp N2 &kp N3 \
-         k20                 k31 k32 k34 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET 
+         k20                 k31 k32 k34 &kp LEFT &kp DOWN &kp UP &kp RIGHT k29 &kp N0 &kp RET
 
 #include "3x5_3.dtsi"

--- a/keymap-drawer/acid.svg
+++ b/keymap-drawer/acid.svg
@@ -583,7 +583,7 @@ text.right {
 </g>
 <g transform="translate(252, 224) rotate(25.0)" class="key kshift keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⏎</text>
+<text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(298, 258) rotate(25.0)" class="key keypos-31">
@@ -592,7 +592,7 @@ text.right {
 </g>
 <g transform="translate(402, 258) rotate(-25.0)" class="key kshift keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⎵</text>
+<text x="0" y="0" class="key kshift tap">⏎</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(448, 224) rotate(-25.0)" class="key keypos-33">
@@ -658,7 +658,7 @@ text.right {
 </g>
 <g transform="translate(504, 38)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↖</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(560, 28)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -666,7 +666,7 @@ text.right {
 </g>
 <g transform="translate(616, 44)" class="key keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↘</text>
+<text x="0" y="0" class="key tap">_</text>
 </g>
 <g transform="translate(672, 62)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/acid.yaml
+++ b/keymap-drawer/acid.yaml
@@ -66,9 +66,9 @@ layers:
   - {left: ん, right: む}
   - {left: ら, right: わ}
   - {left: れ}
-  - {t: ⏎, h: Kana-Shift, type: kshift}
-  - ⌫
   - {t: ⎵, h: Kana-Shift, type: kshift}
+  - ⌫
+  - {t: ⏎, h: Kana-Shift, type: kshift}
   - {t: ⇧⎵, h: Num + Nav}
   Num + Nav:
   - /
@@ -77,9 +77,9 @@ layers:
   - '3'
   - '='
   - ⎋
-  - ↖
+  - ⌫
   - ↑
-  - ↘
+  - _
   - ⏯
   - '*'
   - '4'

--- a/keymap-drawer/bivouac34.svg
+++ b/keymap-drawer/bivouac34.svg
@@ -567,7 +567,7 @@ text.right {
 </g>
 <g transform="translate(200, 267) rotate(33.0)" class="key kshift keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⏎</text>
+<text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(247, 299) rotate(33.0)" class="key keypos-29">
@@ -576,7 +576,7 @@ text.right {
 </g>
 <g transform="translate(394, 299) rotate(-33.0)" class="key kshift keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⎵</text>
+<text x="0" y="0" class="key kshift tap">⏎</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(441, 267) rotate(-33.0)" class="key keypos-31">
@@ -642,7 +642,7 @@ text.right {
 </g>
 <g transform="translate(407, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↖</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(459, 35) rotate(-18.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -650,7 +650,7 @@ text.right {
 </g>
 <g transform="translate(535, 38) rotate(-10.0)" class="key keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↘</text>
+<text x="0" y="0" class="key tap">_</text>
 </g>
 <g transform="translate(595, 56) rotate(-10.0)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/bivouac34.yaml
+++ b/keymap-drawer/bivouac34.yaml
@@ -62,9 +62,9 @@ layers:
   - {left: ん, right: む}
   - {left: ら, right: わ}
   - {left: れ}
-  - {t: ⏎, h: Kana-Shift, type: kshift}
-  - ⌫
   - {t: ⎵, h: Kana-Shift, type: kshift}
+  - ⌫
+  - {t: ⏎, h: Kana-Shift, type: kshift}
   - {t: ⇧⎵, h: Num + Nav}
   Num + Nav:
   - /
@@ -73,9 +73,9 @@ layers:
   - '3'
   - +
   - ⇞
-  - ↖
+  - ⌫
   - ↑
-  - ↘
+  - _
   - ⏯
   - '*'
   - '4'

--- a/keymap-drawer/bivvy16d.svg
+++ b/keymap-drawer/bivvy16d.svg
@@ -225,13 +225,13 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
 </g>
-<g transform="translate(223, 260) rotate(37.0)" class="key high keypos-24">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<g transform="translate(245, 278) rotate(37.0)" class="key high keypos-24">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
 <text x="0" y="24" class="key high hold">⇧</text>
 </g>
-<g transform="translate(474, 260) rotate(-37.0)" class="key high keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<g transform="translate(453, 275) rotate(-37.0)" class="key high keypos-25">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
@@ -293,14 +293,6 @@ text.right {
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
 <text x="0" y="0" class="key tap">↓</text>
 </g>
-<g transform="translate(268, 295) rotate(37.0)" class="key keypos-40">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌫</text>
-</g>
-<g transform="translate(429, 294) rotate(-37.0)" class="key keypos-41">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⇧</text>
-</g>
 <g class="combo combopos-0">
 <path d="M349,12 h-297 a6.0,6.0 0 0 0 -6.0,6.0 v19" class="combo"/>
 <path d="M349,12 h297 a6.0,6.0 0 0 1 6.0,6.0 v19" class="combo"/>
@@ -310,12 +302,12 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-1">
-<path d="M349,195 l-58,-52" class="combo"/>
-<path d="M349,195 l58,-52" class="combo"/>
-<path d="M349,195 l-109,56" class="combo"/>
-<path d="M349,195 l109,56" class="combo"/>
-<rect rx="6" ry="6" x="324" y="182" width="50" height="26" class="combo"/>
-<text x="349" y="195" class="combo tap">
+<path d="M349,203 l-58,-60" class="combo"/>
+<path d="M349,203 l58,-60" class="combo"/>
+<path d="M349,203 l-78,56" class="combo"/>
+<path d="M349,203 l77,53" class="combo"/>
+<rect rx="6" ry="6" x="324" y="190" width="50" height="26" class="combo"/>
+<text x="349" y="203" class="combo tap">
 <tspan x="349" dy="-0.6em">Boot</tspan><tspan x="349" dy="1.2em">loader</tspan>
 </text>
 </g>
@@ -587,13 +579,13 @@ text.right {
 <text x="-24" y="0" class="key left">こ</text>
 <text x="24" y="0" class="key right">、</text>
 </g>
-<g transform="translate(223, 260) rotate(37.0)" class="key kshift keypos-24">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⏎</text>
+<g transform="translate(245, 278) rotate(37.0)" class="key kshift keypos-24">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key kshift"/>
+<text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
-<g transform="translate(474, 260) rotate(-37.0)" class="key keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<g transform="translate(453, 275) rotate(-37.0)" class="key keypos-25">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⇧⎵</text>
 <a href="#Num--Nav">
 <text x="0" y="24" class="key hold layer-activator"><tspan style="font-size: 78%">Num + Nav</tspan></text>
@@ -660,15 +652,6 @@ text.right {
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
 <text x="0" y="0" class="key tap">↓</text>
 </g>
-<g transform="translate(268, 295) rotate(37.0)" class="key keypos-40">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌫</text>
-</g>
-<g transform="translate(429, 294) rotate(-37.0)" class="key kshift keypos-41">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⎵</text>
-<text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
-</g>
 <g class="combo combopos-0">
 <path d="M504,158 h-78 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M504,158 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-45" class="combo"/>
@@ -726,7 +709,7 @@ text.right {
 </g>
 <g transform="translate(463, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↖</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(515, 35) rotate(-18.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -734,7 +717,7 @@ text.right {
 </g>
 <g transform="translate(591, 38) rotate(-10.0)" class="key keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↘</text>
+<text x="0" y="0" class="key tap">_</text>
 </g>
 <g transform="translate(651, 56) rotate(-10.0)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -798,13 +781,13 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
 </g>
-<g transform="translate(223, 260) rotate(37.0)" class="key keypos-24">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<g transform="translate(245, 278) rotate(37.0)" class="key keypos-24">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key"/>
 <text x="0" y="0" class="key tap">0</text>
 <text x="0" y="24" class="key hold">⇧</text>
 </g>
-<g transform="translate(474, 260) rotate(-37.0)" class="key held keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
+<g transform="translate(453, 275) rotate(-37.0)" class="key held keypos-25">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key held"/>
 </g>
 <g transform="translate(502, 186) rotate(-22.0)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -865,14 +848,6 @@ text.right {
 <g transform="translate(599, 315)" class="key keypos-39">
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
 <text x="0" y="0" class="key tap">↓</text>
-</g>
-<g transform="translate(268, 295) rotate(37.0)" class="key trans keypos-40">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
-</g>
-<g transform="translate(429, 294) rotate(-37.0)" class="key trans keypos-41">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g class="combo combopos-0">
 <path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>

--- a/keymap-drawer/bivvy16d.yaml
+++ b/keymap-drawer/bivvy16d.yaml
@@ -1,4 +1,4 @@
-layout: {zmk_keyboard: bivvy16d}
+layout: {zmk_keyboard: bivvy16d, layout_name: bivvy16d_L15_R15_layout}
 layers:
   HD Promethium:
   - ⎋
@@ -41,8 +41,6 @@ layers:
   - ⏎
   - →
   - ↓
-  - ⌫
-  - ⇧
   Naginata:
   - {t: ⎋, h: Small-kana}
   - {left: き, right: め}
@@ -68,7 +66,7 @@ layers:
   - {left: ひ}
   - {left: は, right: を}
   - {h: 半濁音, left: こ, right: 、}
-  - {t: ⏎, h: Kana-Shift, type: kshift}
+  - {t: ⎵, h: Kana-Shift, type: kshift}
   - {t: ⇧⎵, h: Num + Nav}
   - {h: 半濁音, left: な, right: 。}
   - {left: ん, right: む}
@@ -84,8 +82,6 @@ layers:
   - ⏎
   - →
   - ↓
-  - ⌫
-  - {t: ⎵, h: Kana-Shift, type: kshift}
   Num + Nav:
   - /
   - '1'
@@ -93,9 +89,9 @@ layers:
   - '3'
   - +
   - ⇞
-  - ↖
+  - ⌫
   - ↑
-  - ↘
+  - _
   - ⏯
   - '*'
   - '4'
@@ -131,8 +127,6 @@ layers:
   - ⏎
   - →
   - ↓
-  - {t: ▽, type: trans}
-  - {t: ▽, type: trans}
 combos:
 - p: [0, 9]
   k: Studio Unlock

--- a/keymap-drawer/goldilocks32.svg
+++ b/keymap-drawer/goldilocks32.svg
@@ -1,4 +1,4 @@
-<svg width="700" height="1271" viewBox="0 0 700 1271" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="700" height="1227" viewBox="0 0 700 1227" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -225,13 +225,13 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
 </g>
-<g transform="translate(223, 270) rotate(37.0)" class="key high keypos-24">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<g transform="translate(251, 274) rotate(37.0)" class="key high keypos-24">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
 <text x="0" y="24" class="key high hold">⇧</text>
 </g>
-<g transform="translate(417, 270) rotate(-37.0)" class="key high keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<g transform="translate(389, 274) rotate(-37.0)" class="key high keypos-25">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
@@ -271,14 +271,6 @@ text.right {
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
 <text x="0" y="0" class="key tap">↓</text>
 </g>
-<g transform="translate(268, 309) rotate(37.0)" class="key keypos-35">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌫</text>
-</g>
-<g transform="translate(372, 309) rotate(-37.0)" class="key keypos-36">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⇧</text>
-</g>
 <g class="combo combopos-0">
 <path d="M320,9 h-268 a6.0,6.0 0 0 0 -6.0,6.0 v23" class="combo"/>
 <path d="M320,9 h268 a6.0,6.0 0 0 1 6.0,6.0 v23" class="combo"/>
@@ -288,12 +280,12 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-1">
-<path d="M320,203 l-34,-52" class="combo"/>
-<path d="M320,203 l34,-52" class="combo"/>
-<path d="M320,203 l-82,57" class="combo"/>
-<path d="M320,203 l82,57" class="combo"/>
-<rect rx="6" ry="6" x="295" y="190" width="50" height="26" class="combo"/>
-<text x="320" y="203" class="combo tap">
+<path d="M320,205 l-34,-54" class="combo"/>
+<path d="M320,205 l34,-54" class="combo"/>
+<path d="M320,205 l-47,47" class="combo"/>
+<path d="M320,205 l47,47" class="combo"/>
+<rect rx="6" ry="6" x="295" y="192" width="50" height="26" class="combo"/>
+<text x="320" y="205" class="combo tap">
 <tspan x="320" dy="-0.6em">Boot</tspan><tspan x="320" dy="1.2em">loader</tspan>
 </text>
 </g>
@@ -441,7 +433,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 407)" class="layer-Naginata">
+<g transform="translate(30, 393)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 65) rotate(10.0)" class="key keypos-0">
@@ -565,13 +557,13 @@ text.right {
 <text x="-24" y="0" class="key left">こ</text>
 <text x="24" y="0" class="key right">、</text>
 </g>
-<g transform="translate(223, 270) rotate(37.0)" class="key kshift keypos-24">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⏎</text>
+<g transform="translate(251, 274) rotate(37.0)" class="key kshift keypos-24">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key kshift"/>
+<text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
-<g transform="translate(417, 270) rotate(-37.0)" class="key keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<g transform="translate(389, 274) rotate(-37.0)" class="key keypos-25">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⇧⎵</text>
 <a href="#Num--Nav">
 <text x="0" y="24" class="key hold layer-activator"><tspan style="font-size: 78%">Num + Nav</tspan></text>
@@ -616,15 +608,6 @@ text.right {
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
 <text x="0" y="0" class="key tap">↓</text>
 </g>
-<g transform="translate(268, 309) rotate(37.0)" class="key keypos-35">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌫</text>
-</g>
-<g transform="translate(372, 309) rotate(-37.0)" class="key kshift keypos-36">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⎵</text>
-<text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
-</g>
 <g class="combo combopos-0">
 <path d="M447,164 h-77 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M447,164 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-49" class="combo"/>
@@ -653,7 +636,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 811)" class="layer-Num + Nav">
+<g transform="translate(30, 782)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 65) rotate(10.0)" class="key keypos-0">
@@ -682,7 +665,7 @@ text.right {
 </g>
 <g transform="translate(407, 85) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↖</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(459, 35) rotate(-18.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -690,7 +673,7 @@ text.right {
 </g>
 <g transform="translate(534, 38) rotate(-10.0)" class="key keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↘</text>
+<text x="0" y="0" class="key tap">_</text>
 </g>
 <g transform="translate(594, 65) rotate(-10.0)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-37" width="52" height="74" class="key"/>
@@ -754,13 +737,13 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
 </g>
-<g transform="translate(223, 270) rotate(37.0)" class="key keypos-24">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<g transform="translate(251, 274) rotate(37.0)" class="key keypos-24">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key"/>
 <text x="0" y="0" class="key tap">0</text>
 <text x="0" y="24" class="key hold">⇧</text>
 </g>
-<g transform="translate(417, 270) rotate(-37.0)" class="key held keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
+<g transform="translate(389, 274) rotate(-37.0)" class="key held keypos-25">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key held"/>
 </g>
 <g transform="translate(445, 192) rotate(-22.0)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -799,14 +782,6 @@ text.right {
 <g transform="translate(95, 308)" class="key keypos-34">
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
 <text x="0" y="0" class="key tap">↓</text>
-</g>
-<g transform="translate(268, 309) rotate(37.0)" class="key trans keypos-35">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
-</g>
-<g transform="translate(372, 309) rotate(-37.0)" class="key trans keypos-36">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g class="combo combopos-0">
 <path d="M169,220 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>

--- a/keymap-drawer/goldilocks32.yaml
+++ b/keymap-drawer/goldilocks32.yaml
@@ -1,4 +1,4 @@
-layout: {zmk_keyboard: goldilocks32, layout_name: physical_layout32}
+layout: {zmk_keyboard: goldilocks32, layout_name: physical_layout30}
 layers:
   HD Promethium:
   - ⎋
@@ -36,8 +36,6 @@ layers:
   - ⏎
   - →
   - ↓
-  - ⌫
-  - ⇧
   Naginata:
   - {t: ⎋, h: Small-kana}
   - {left: き, right: め}
@@ -63,7 +61,7 @@ layers:
   - {left: ひ}
   - {left: は, right: を}
   - {h: 半濁音, left: こ, right: 、}
-  - {t: ⏎, h: Kana-Shift, type: kshift}
+  - {t: ⎵, h: Kana-Shift, type: kshift}
   - {t: ⇧⎵, h: Num + Nav}
   - {h: 半濁音, left: な, right: 。}
   - {left: ん, right: む}
@@ -74,8 +72,6 @@ layers:
   - ⏎
   - →
   - ↓
-  - ⌫
-  - {t: ⎵, h: Kana-Shift, type: kshift}
   Num + Nav:
   - /
   - '1'
@@ -83,9 +79,9 @@ layers:
   - '3'
   - +
   - ⇞
-  - ↖
+  - ⌫
   - ↑
-  - ↘
+  - _
   - ⏯
   - '*'
   - '4'
@@ -116,8 +112,6 @@ layers:
   - ⏎
   - →
   - ↓
-  - {t: ▽, type: trans}
-  - {t: ▽, type: trans}
 combos:
 - p: [0, 9]
   k: Studio Unlock

--- a/keymap-drawer/hesse.svg
+++ b/keymap-drawer/hesse.svg
@@ -598,7 +598,7 @@ text.right {
 </g>
 <g transform="translate(199, 274) rotate(37.0)" class="key kshift keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⏎</text>
+<text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
@@ -607,7 +607,7 @@ text.right {
 </g>
 <g transform="translate(475, 320) rotate(-38.0)" class="key kshift keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⎵</text>
+<text x="0" y="0" class="key kshift tap">⏎</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(521, 274) rotate(-37.0)" class="key keypos-34">
@@ -680,7 +680,7 @@ text.right {
 </g>
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↖</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -688,7 +688,7 @@ text.right {
 </g>
 <g transform="translate(613, 38) rotate(-10.0)" class="key keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↘</text>
+<text x="0" y="0" class="key tap">_</text>
 </g>
 <g transform="translate(692, 63)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/hesse.yaml
+++ b/keymap-drawer/hesse.yaml
@@ -69,9 +69,9 @@ layers:
   - {left: ら, right: わ}
   - {left: れ}
   - ↹
-  - {t: ⏎, h: Kana-Shift, type: kshift}
-  - ⌫
   - {t: ⎵, h: Kana-Shift, type: kshift}
+  - ⌫
+  - {t: ⏎, h: Kana-Shift, type: kshift}
   - {t: ⇧⎵, h: Num + Nav}
   - Num + Nav
   Num + Nav:
@@ -81,9 +81,9 @@ layers:
   - '3'
   - '='
   - ⎋
-  - ↖
+  - ⌫
   - ↑
-  - ↘
+  - _
   - ⏯
   - '*'
   - '4'

--- a/keymap-drawer/slump52.svg
+++ b/keymap-drawer/slump52.svg
@@ -299,17 +299,19 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
 </g>
-<g transform="translate(300, 258) rotate(35.0)" class="key keypos-42">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌫</text>
+<g transform="translate(300, 258) rotate(35.0)" class="key high keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(347, 297) rotate(-45.0)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⇧</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
-<g transform="translate(393, 258) rotate(-35.0)" class="key keypos-44">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⇧</text>
+<g transform="translate(393, 258) rotate(-35.0)" class="key high keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(547, 301) rotate(-11.5)" class="key keypos-45">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -662,7 +664,7 @@ text.right {
 </g>
 <g transform="translate(248, 228) rotate(25.0)" class="key kshift keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⏎</text>
+<text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(446, 228) rotate(-25.0)" class="key keypos-33">
@@ -708,19 +710,21 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="-24" y="0" class="key left">ほ</text>
 </g>
-<g transform="translate(300, 258) rotate(35.0)" class="key keypos-42">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌫</text>
-</g>
-<g transform="translate(347, 297) rotate(-45.0)" class="key keypos-43">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⇧</text>
-</g>
-<g transform="translate(393, 258) rotate(-35.0)" class="key kshift keypos-44">
+<g transform="translate(300, 258) rotate(35.0)" class="key kshift keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
 <text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
+<g transform="translate(347, 297) rotate(-45.0)" class="key keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+</g>
+<g transform="translate(393, 258) rotate(-35.0)" class="key keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⇧⎵</text>
+<a href="#Num--Nav">
+<text x="0" y="24" class="key hold layer-activator"><tspan style="font-size: 78%">Num + Nav</tspan></text>
+</a></g>
 <g transform="translate(547, 301) rotate(-11.5)" class="key keypos-45">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">←</text>
@@ -810,7 +814,7 @@ text.right {
 </g>
 <g transform="translate(437, 77) rotate(-25.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↖</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(491, 54) rotate(-21.0)" class="key keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -818,7 +822,7 @@ text.right {
 </g>
 <g transform="translate(548, 38) rotate(-12.0)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↘</text>
+<text x="0" y="0" class="key tap">_</text>
 </g>
 <g transform="translate(608, 30) rotate(-3.0)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -950,13 +954,14 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
 </g>
-<g transform="translate(300, 258) rotate(35.0)" class="key trans keypos-42">
+<g transform="translate(300, 258) rotate(35.0)" class="key keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">0</text>
+<text x="0" y="24" class="key hold">⇧</text>
+</g>
+<g transform="translate(347, 297) rotate(-45.0)" class="key trans keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
-</g>
-<g transform="translate(347, 297) rotate(-45.0)" class="key keypos-43">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⇧</text>
 </g>
 <g transform="translate(393, 258) rotate(-35.0)" class="key trans keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>

--- a/keymap-drawer/slump52.yaml
+++ b/keymap-drawer/slump52.yaml
@@ -43,9 +43,9 @@ layers:
   - '2'
   - '3'
   - {t: bB, type: medium-low}
+  - {t: rR, h: ⇧, type: high}
   - ⌫
-  - ⇧
-  - ⇧
+  - {t: ⎵, h: Num+Nav, type: high}
   - ←
   - ↓
   - ↑
@@ -86,7 +86,7 @@ layers:
   - {left: ひ}
   - {left: は, right: を}
   - {h: 半濁音, left: こ, right: 、}
-  - {t: ⏎, h: Kana-Shift, type: kshift}
+  - {t: ⎵, h: Kana-Shift, type: kshift}
   - {t: ⇧⎵, h: Num + Nav}
   - {h: 半濁音, left: な, right: 。}
   - {left: ん, right: む}
@@ -96,9 +96,9 @@ layers:
   - '2'
   - '3'
   - {left: ほ}
-  - ⌫
-  - ⇧
   - {t: ⎵, h: Kana-Shift, type: kshift}
+  - ⌫
+  - {t: ⇧⎵, h: Num + Nav}
   - ←
   - ↓
   - ↑
@@ -114,9 +114,9 @@ layers:
   - '3'
   - +
   - ⇞
-  - ↖
+  - ⌫
   - ↑
-  - ↘
+  - _
   - ⏯
   - '*'
   - '7'
@@ -151,8 +151,8 @@ layers:
   - '2'
   - '3'
   - .
+  - {t: '0', h: ⇧}
   - {t: ▽, type: trans}
-  - ⇧
   - {t: ▽, type: trans}
   - ←
   - ↓

--- a/keymap-drawer/tc36k.svg
+++ b/keymap-drawer/tc36k.svg
@@ -598,7 +598,7 @@ text.right {
 </g>
 <g transform="translate(199, 274) rotate(37.0)" class="key kshift keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⏎</text>
+<text x="0" y="0" class="key kshift tap">⎵</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
@@ -607,7 +607,7 @@ text.right {
 </g>
 <g transform="translate(475, 320) rotate(-38.0)" class="key kshift keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key kshift"/>
-<text x="0" y="0" class="key kshift tap">⎵</text>
+<text x="0" y="0" class="key kshift tap">⏎</text>
 <text x="0" y="24" class="key kshift hold"><tspan style="font-size: 70%">Kana-Shift</tspan></text>
 </g>
 <g transform="translate(521, 274) rotate(-37.0)" class="key keypos-34">
@@ -680,7 +680,7 @@ text.right {
 </g>
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↖</text>
+<text x="0" y="0" class="key tap">⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -688,7 +688,7 @@ text.right {
 </g>
 <g transform="translate(613, 38) rotate(-10.0)" class="key keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↘</text>
+<text x="0" y="0" class="key tap">_</text>
 </g>
 <g transform="translate(692, 63)" class="key keypos-9">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/keymap-drawer/tc36k.yaml
+++ b/keymap-drawer/tc36k.yaml
@@ -69,9 +69,9 @@ layers:
   - {left: ら, right: わ}
   - {left: れ}
   - ↹
-  - {t: ⏎, h: Kana-Shift, type: kshift}
-  - ⌫
   - {t: ⎵, h: Kana-Shift, type: kshift}
+  - ⌫
+  - {t: ⏎, h: Kana-Shift, type: kshift}
   - {t: ⇧⎵, h: Num + Nav}
   - Num + Nav
   Num + Nav:
@@ -81,9 +81,9 @@ layers:
   - '3'
   - '='
   - ⎋
-  - ↖
+  - ⌫
   - ↑
-  - ↘
+  - _
   - ⏯
   - '*'
   - '4'

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -101,6 +101,8 @@ parse_config:
     C_PAUSE: '⏯'
     C_PLAY_PAUSE: '⏯'
     C_MUTE: "VOL\nMUTE"
+    C_VOL_DOWN: "VOL\nDOWN"
+    C_VOL_UP: "VOL\nUP"
     C_VOLUME_DOWN: "VOL\nDOWN"
     C_VOLUME_UP: "VOL\nUP"
     K_VOLUME_DOWN: "VOL\nDOWN"

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -101,8 +101,6 @@ parse_config:
     C_PAUSE: '⏯'
     C_PLAY_PAUSE: '⏯'
     C_MUTE: "VOL\nMUTE"
-    C_VOL_DOWN: "VOL\nDOWN"
-    C_VOL_UP: "VOL\nUP"
     C_VOLUME_DOWN: "VOL\nDOWN"
     C_VOLUME_UP: "VOL\nUP"
     K_VOLUME_DOWN: "VOL\nDOWN"
@@ -199,7 +197,6 @@ parse_config:
     '&kp SPACE': {'t': '⎵', 'type': 'high'}
     '&blt NUM_NAV SPACE': {'t': '⎵', 'h': 'Num+Nav', 'type': 'high'}
     '&bmt LSHFT R': {'t': 'rR', 'h': '⇧', 'type': 'high'}
-    '&kp RS(R)': {'t': 'R'}
     # And again for auto-shift:
     'AS(Q)': {'t': 'qQ', 'type': 'low'}
     'AS(W)': {'t': 'wW', 'type': 'medium'}

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -197,6 +197,7 @@ parse_config:
     '&kp SPACE': {'t': '⎵', 'type': 'high'}
     '&blt NUM_NAV SPACE': {'t': '⎵', 'h': 'Num+Nav', 'type': 'high'}
     '&bmt LSHFT R': {'t': 'rR', 'h': '⇧', 'type': 'high'}
+    '&kp RS(R)': {'t': 'R'}
     # And again for auto-shift:
     'AS(Q)': {'t': 'qQ', 'type': 'low'}
     'AS(W)': {'t': 'wW', 'type': 'medium'}


### PR DESCRIPTION
For the Goldilocks32 and Bivvy16D keyboards in particular which were designed with this option in mind.

Note tried out number pad changes (esp zero to allow for capital R), and loss of home/end on the nav layer (to allow Naginata style backspace to be there too).