### PR TITLE
Autoshift reprise (co-existing with magic comma)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ of word, and forward to start of next word in Vim or Helix.
 Most of the symbols are 2-key vertical combos, the brackets are 2-key horizontal
 combos (open on the left hand, close on the right).
 
+This has *Auto Shift* setup, meaning a long tap on the base layer letters and
+symbols gives the capital or shifted form. I am also trying out *Magic Comma Shift*
+whereby typing comma then a letter will give the capital version of the letter -
+but typing comma and space just works as usual.
+
 I wanted to be able to use this on my laptop too - achieved with [custom Karabiner-Elements
 rules](https://codeberg.org/peterjc/kana-chording-ke/src/branch/main/hands-down-on-jis-macbook)
 (see this [blog post](https://blastedbio.blogspot.com/2025/05/what-have-you-done-to-your-keyboard.html)).
@@ -41,9 +46,6 @@ hand has navigation keys including an inverted-tee set of cursors at the Qwerty
 JKIL position inspired by [Dreymar's Extend layer](https://dreymar.colemak.org/layers-extend.html).
 The left hand has a number-pad, with 123 at the top like a mobile phone (since
 in a traditional keyboard 123 are about there).
-
-I am trying *Magic Comma Shift* whereby typing comma then a letter will give the
-capital version of the letter - but typing comma and space just works as usual.
 
 ## Split 3x5_3 aka 33333+3 Layout with 36 keys
 

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -232,10 +232,19 @@
             keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
         };
 
+        magic_comma_ht: magic_comma_ht {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            tapping_term_ms = <my_linger_term>;
+            quick_tap_ms = <250>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&magic_comma_shift>;
+        };
+
         comma_semi: comma_semi {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&magic_comma_shift>, <&kp SEMI>;
+            bindings = <&magic_comma_ht SEMI 0>, <&kp SEMI>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
             // do NOT want to keep shift active, but anything else is fine:
             keep-mods = <(MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -414,6 +414,22 @@
             timeout-ms = <40>;
         };
 
+        // 2-key horizontal bottom-row combos for shift
+        left_shift_combo {
+            bindings = <&kp LSHFT>;
+            key-positions = <LB1 LB2>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
+        right_shift_combo {
+            bindings = <&kp RSHFT>;
+            key-positions = <RB1 RB2>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
+
         // 2-key horizontal combos for rare letters
         q_combo {
             bindings = <AS(Q)>;

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -31,6 +31,10 @@
 #define NAGINATA 1
 #define NUM_NAV 2
 
+#define my_linger_term 300// linger mod-tap trigger time window
+
+#define AS(keycode) &as LS(keycode) keycode     // Autoshift Macro
+
 / {
     macros {
         // To switch to Japanese mode, this sends what Karabiner-Elements sees
@@ -152,6 +156,15 @@
             // (Staying with default limit of 32 definitions)
         };
 
+        as: auto_shift {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            tapping_term_ms = <my_linger_term>;
+            quick_tap_ms = <250>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+
         hpmt: hold_preferred_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
@@ -190,7 +203,7 @@
         xquote: override_shift_quote {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&kp SQT>, <&kp N2>;
+            bindings = <&as LS(N2) SQT>, <&kp N2>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
             // need to keep shift, and anything else too:
             keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
@@ -200,20 +213,20 @@
         open_par_lt: open_par_lt {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&kp LEFT_PARENTHESIS>, <&kp LESS_THAN>;
+            bindings = <&as LESS_THAN LEFT_PARENTHESIS>, <&kp LESS_THAN>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
         };
         close_par_gt: close_par_gt {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&kp RIGHT_PARENTHESIS>, <&kp GREATER_THAN>;
+            bindings = <&as GREATER_THAN RIGHT_PARENTHESIS>, <&kp GREATER_THAN>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
         };
 
         dot_colon: dot_colon {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&kp DOT>, <&kp COLON>;
+            bindings = <&as COLON DOT>, <&kp COLON>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
             // need to keep shift, and anything else too:
             keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
@@ -238,10 +251,10 @@
         default_layer {
             display-name = "HD Promethium";
             bindings = <LAYER_FROM36( \
-                &kp ESCAPE, &kp P, &kp G, &kp M, &kp X,      &kp SLASH,   &kp BSPC, &xquote, &kp MINUS, &kp EQUAL, \
-                &kp S,      &kp N, &kp T, &kp H, &kp K,      &dot_colon,  &kp A,    &kp E,   &kp I,     &kp C,  \
-                &kp B,      &kp F, &kp D, &kp L, &kp J,      &comma_semi, &kp U,    &kp O,   &kp Y,     &kp W,  \
-                &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC,     &kp RSHFT, &blt NUM_NAV SPACE, &mo NUM_NAV \
+                &kp ESCAPE, AS(P), AS(G), AS(M), AS(X),      AS(SLASH),   AS(BSPC), &xquote, AS(MINUS), AS(EQUAL), \
+                AS(S),      AS(N), AS(T), AS(H), AS(K),      &dot_colon,  AS(A),    AS(E),   AS(I),     AS(C),  \
+                AS(B),      AS(F), AS(D), AS(L), AS(J),      &comma_semi, AS(U),    AS(O),   AS(Y),     AS(W),  \
+                      &kp TAB, AS(R), &hpmt LSHFT BSPC,      &kp RSHFT, &blt NUM_NAV SPACE, &mo NUM_NAV \
             )>;
         };
 
@@ -403,28 +416,28 @@
 
         // 2-key horizontal combos for rare letters
         q_combo {
-            bindings = <&kp Q>;
+            bindings = <AS(Q)>;
             key-positions = <LT1 LT2>;
             layers = <DEFAULT>;
             timeout-ms = <100>;
         };
 
         z_combo {
-            bindings = <&kp Z>;
+            bindings = <AS(Z)>;
             key-positions = <RT2 RT3>;
             layers = <DEFAULT>;
             timeout-ms = <75>;
         };
 
         v_combo {
-            bindings = <&kp V>;
+            bindings = <AS(V)>;
             key-positions = <LT2 LT3>;
             layers = <DEFAULT>;
             timeout-ms = <75>;
         };
 
         x_combo {
-            bindings = <&kp X>;
+            bindings = <AS(X)>;
             key-positions = <LB2 LB3>;
             layers = <DEFAULT>;
             timeout-ms = <75>;
@@ -519,7 +532,7 @@
             layers = <DEFAULT NUM_NAV>;
         };
 
-        // 2-key horizontal combos for {}, can also use shift with [] combos:
+        // 2-key horizontal combos for {}, can instead use shift with the [] combos:
 #ifndef LT0
         open_curly {
             bindings = <&kp LEFT_BRACE>;
@@ -575,13 +588,13 @@
 
         // 2-key horizontal combos for [] with shifted form {}
         open_square_curly {
-            bindings = <&kp LEFT_BRACKET>;
+            bindings = <AS(LEFT_BRACKET)>;
             key-positions = <LB0 LB1>;
             layers = <DEFAULT NUM_NAV>;
         };
 
         close_square_curly {
-            bindings = <&kp RIGHT_BRACKET>;
+            bindings = <AS(RIGHT_BRACKET)>;
             key-positions = <RB0 RB1>;
             layers = <DEFAULT NUM_NAV>;
         };

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -443,6 +443,13 @@
             timeout-ms = <75>;
         };
 
+        caps_word_combo {
+            bindings = <&caps_word>;
+            key-positions = <LH1 RH1>;
+            layers = <DEFAULT>;
+            timeout-ms = <75>;
+        };
+
         // 2-key vertical combos (symbols)
         backtick {
             bindings = <&kp GRAVE>;

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -185,24 +185,6 @@
             bindings = <&mo>, <&kp>;
         };
 
-        space_R: space_R {
-            compatible = "zmk,behavior-mod-morph";
-            #binding-cells = <0>;
-            bindings = <&kp SPACE>, <&kp R>;
-            mods = <(MOD_LSFT|MOD_RSFT)>;
-            // need to keep shift, and anything else too:
-            keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
-        };
-        space_R_layer: space_R_layer {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "balanced";
-            tapping-term-ms = <300>;
-            quick-tap-ms = <250>;
-            bindings = <&mo>, <&space_R>;
-            display-name = "Space/R/Layer";
-        };
-
         // make shift+quote give double-quote like ANSI or Apple UK
         // when host setup with British layout (would be @-sign)
         xquote: override_shift_quote {
@@ -259,7 +241,7 @@
                 &kp ESCAPE, &kp P, &kp G, &kp M, &kp X,      &kp SLASH,   &kp BSPC, &xquote, &kp MINUS, &kp EQUAL, \
                 &kp S,      &kp N, &kp T, &kp H, &kp K,      &dot_colon,  &kp A,    &kp E,   &kp I,     &kp C,  \
                 &kp B,      &kp F, &kp D, &kp L, &kp J,      &comma_semi, &kp U,    &kp O,   &kp Y,     &kp W,  \
-                &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC,     &kp RSHFT, &space_R_layer NUM_NAV 0, &mo NUM_NAV \
+                &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC,     &kp RSHFT, &blt NUM_NAV SPACE, &mo NUM_NAV \
             )>;
         };
 
@@ -444,13 +426,6 @@
         x_combo {
             bindings = <&kp X>;
             key-positions = <LB2 LB3>;
-            layers = <DEFAULT>;
-            timeout-ms = <75>;
-        };
-
-        shift_space_combo {
-            bindings = <&kp LS(SPACE)>;
-            key-positions = <LH1 RH1>;
             layers = <DEFAULT>;
             timeout-ms = <75>;
         };

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -381,9 +381,21 @@
             layers = <DEFAULT NUM_NAV>;
             require-prior-idle-ms = <250>;
         };
+        right_alt_combo {
+            bindings = <&kp RALT>;
+            key-positions = <RM3 RM4>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+        };
         left_ctrl_combo {
             bindings = <&kp LCTRL>;
             key-positions = <LM2 LM3>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+        };
+        right_ctrl_combo {
+            bindings = <&kp RCTRL>;
+            key-positions = <RM2 RM3>;
             layers = <DEFAULT NUM_NAV>;
             require-prior-idle-ms = <250>;
         };
@@ -393,18 +405,6 @@
             layers = <DEFAULT NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
-        };
-        right_alt_combo {
-            bindings = <&kp RALT>;
-            key-positions = <RM3 RM4>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-        };
-        right_ctrl_combo {
-            bindings = <&kp RCTRL>;
-            key-positions = <RM2 RM3>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
         };
         right_gui_combo {
             bindings = <&kp RGUI>;

--- a/keymap-drawer/acid.svg
+++ b/keymap-drawer/acid.svg
@@ -156,6 +156,7 @@ text.right {
 <g transform="translate(504, 38)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(560, 28)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -252,7 +253,6 @@ text.right {
 <g transform="translate(252, 224) rotate(25.0)" class="key high keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(298, 258) rotate(25.0)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -265,7 +265,7 @@ text.right {
 </g>
 <g transform="translate(448, 224) rotate(-25.0)" class="key high keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g class="combo combopos-0">
@@ -317,120 +317,128 @@ text.right {
 <text x="56" y="109" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-7">
-<rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
-<text x="112" y="92" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
-<text x="168" y="89" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-9">
 <rect rx="6" ry="6" x="630" y="96" width="28" height="26" class="combo"/>
 <text x="644" y="109" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
+<text x="112" y="92" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="574" y="79" width="28" height="26" class="combo"/>
 <text x="588" y="92" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-10">
+<rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
+<text x="168" y="89" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-11">
 <rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
 <text x="532" y="89" class="combo tap">⌘</text>
 </g>
-<g class="combo low combopos-12">
-<rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo low"/>
-<text x="168" y="33" class="combo low tap">vQ</text>
+<g class="combo combopos-12">
+<rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
+<text x="168" y="145" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-13">
+<g class="combo combopos-13">
+<rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
+<text x="532" y="145" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-14">
+<rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo low"/>
+<text x="168" y="33" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-15">
 <rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo low"/>
 <text x="588" y="36" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-16">
 <rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo low"/>
 <text x="112" y="36" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-17">
 <rect rx="6" ry="6" x="98" y="135" width="28" height="26" class="combo low"/>
 <text x="112" y="148" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <path d="M350,224 l-79,0" class="combo"/>
 <path d="M350,224 l79,0" class="combo"/>
 <rect rx="6" ry="6" x="336" y="211" width="28" height="26" class="combo"/>
-<text x="350" y="224" class="combo tap">⇧⎵</text>
+<text x="350" y="224" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
 <text x="28" y="90" class="combo tap">`</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
 <text x="84" y="72" class="combo tap">@</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
 <text x="140" y="56" class="combo tap">|</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
 <text x="196" y="66" class="combo tap">$</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="238" y="59" width="28" height="26" class="combo"/>
 <text x="252" y="72" class="combo tap">\</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <path d="M281,128 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M281,128 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
 <rect rx="6" ry="6" x="267" y="115" width="28" height="26" class="combo"/>
 <text x="281" y="128" class="combo tap">%</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <path d="M419,128 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M419,128 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
 <rect rx="6" ry="6" x="405" y="115" width="28" height="26" class="combo"/>
 <text x="419" y="128" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="434" y="59" width="28" height="26" class="combo"/>
 <text x="448" y="72" class="combo tap">/</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
 <text x="504" y="66" class="combo tap">?</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
 <text x="560" y="56" class="combo tap">#</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
 <text x="616" y="72" class="combo tap">!</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
 <text x="672" y="90" class="combo tap">~</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
 <text x="224" y="41" class="combo tap">{</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
 <text x="476" y="41" class="combo tap">}</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
 <text x="224" y="97" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
 <text x="476" y="97" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
 <text x="224" y="153" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
 <text x="476" y="153" class="combo tap">]}</text>
 </g>
@@ -798,123 +806,131 @@ text.right {
 <text x="56" y="109" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-3">
-<rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
-<text x="112" y="92" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
-<text x="168" y="89" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-5">
 <rect rx="6" ry="6" x="630" y="96" width="28" height="26" class="combo"/>
 <text x="644" y="109" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
+<text x="112" y="92" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="574" y="79" width="28" height="26" class="combo"/>
 <text x="588" y="92" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
+<text x="168" y="89" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-7">
 <rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
 <text x="532" y="89" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-8">
+<rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
+<text x="168" y="145" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
+<text x="532" y="145" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
 <text x="28" y="90" class="combo tap">`</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
 <text x="84" y="72" class="combo tap">@</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
 <text x="140" y="56" class="combo tap">|</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
 <text x="196" y="66" class="combo tap">$</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="238" y="59" width="28" height="26" class="combo"/>
 <text x="252" y="72" class="combo tap">\</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-15">
 <path d="M281,128 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M281,128 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
 <rect rx="6" ry="6" x="267" y="115" width="28" height="26" class="combo"/>
 <text x="281" y="128" class="combo tap">%</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-16">
 <path d="M419,128 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M419,128 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
 <rect rx="6" ry="6" x="405" y="115" width="28" height="26" class="combo"/>
 <text x="419" y="128" class="combo tap">^</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="434" y="59" width="28" height="26" class="combo"/>
 <text x="448" y="72" class="combo tap">/</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
 <text x="504" y="66" class="combo tap">?</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
 <text x="560" y="56" class="combo tap">#</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
 <text x="616" y="72" class="combo tap">!</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
 <text x="672" y="90" class="combo tap">~</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
 <text x="224" y="41" class="combo tap">{</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
 <text x="476" y="41" class="combo tap">}</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
 <text x="224" y="97" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
 <text x="476" y="97" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
 <text x="224" y="153" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
 <text x="476" y="153" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="42" y="40" width="28" height="26" class="combo"/>
 <text x="56" y="53" class="combo tap">BT</text>
 <text x="56" y="64" class="combo hold">0</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo"/>
 <text x="112" y="36" class="combo tap">BT</text>
 <text x="112" y="47" class="combo hold">1</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo"/>
 <text x="168" y="33" class="combo tap">BT</text>
 <text x="168" y="44" class="combo hold">2</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="518" y="20" width="28" height="26" class="combo"/>
 <text x="532" y="33" class="combo tap">
 <tspan x="532" dy="-0.6em">BT</tspan><tspan x="532" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo"/>
 <text x="588" y="36" class="combo tap">
 <tspan x="588" dy="-0.6em">BT</tspan><tspan x="588" dy="1.2em">…</tspan>

--- a/keymap-drawer/acid.yaml
+++ b/keymap-drawer/acid.yaml
@@ -7,7 +7,7 @@ layers:
   - {t: mM, type: medium}
   - {t: xX, type: low}
   - {t: '/?', type: low}
-  - ⌫
+  - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -31,10 +31,10 @@ layers:
   - {t: oO, type: high}
   - {t: yY, type: medium}
   - {t: wW, type: medium}
-  - {t: rR, h: ⇧, type: high}
+  - {t: rR, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   Naginata:
   - {t: ⎋, h: Small-kana}
   - {left: き, right: め}
@@ -149,23 +149,29 @@ combos:
 - p: [11, 10]
   k: ⎇
   l: [HD Promethium, Num + Nav]
+- p: [18, 19]
+  k: ⎇
+  l: [HD Promethium, Num + Nav]
 - p: [12, 11]
+  k: ⌃
+  l: [HD Promethium, Num + Nav]
+- p: [17, 18]
   k: ⌃
   l: [HD Promethium, Num + Nav]
 - p: [13, 12]
   k: ⌘
   l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [23, 22]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
+- p: [26, 27]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: vQ, type: low}
+  k: {t: qQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}
@@ -177,7 +183,7 @@ combos:
   k: {t: xX, type: low}
   l: [HD Promethium]
 - p: [30, 33]
-  k: ⇧⎵
+  k: ⇪
   l: [HD Promethium]
 - p: [0, 10]
   k: '`'

--- a/keymap-drawer/bivouac34.svg
+++ b/keymap-drawer/bivouac34.svg
@@ -156,6 +156,7 @@ text.right {
 <g transform="translate(407, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(459, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -244,7 +245,6 @@ text.right {
 <g transform="translate(200, 267) rotate(33.0)" class="key high keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(247, 299) rotate(33.0)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -257,7 +257,7 @@ text.right {
 </g>
 <g transform="translate(441, 267) rotate(-33.0)" class="key high keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g class="combo combopos-0">
@@ -309,120 +309,128 @@ text.right {
 <text x="63" y="110" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-7">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-9">
 <rect rx="6" ry="6" x="565" y="97" width="28" height="26" class="combo"/>
 <text x="579" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="496" y="78" width="28" height="26" class="combo"/>
 <text x="510" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-10">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-11">
 <rect rx="6" ry="6" x="437" y="98" width="28" height="26" class="combo"/>
 <text x="451" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo low combopos-12">
-<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">vQ</text>
+<g class="combo combopos-12">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-13">
+<g class="combo combopos-13">
+<rect rx="6" ry="6" x="455" y="151" width="28" height="26" class="combo"/>
+<text x="469" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-14">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-15">
 <rect rx="6" ry="6" x="483" y="24" width="28" height="26" class="combo low"/>
 <text x="497" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-16">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-17">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <path d="M321,267 l-102,0" class="combo"/>
 <path d="M321,267 l102,0" class="combo"/>
 <rect rx="6" ry="6" x="307" y="254" width="28" height="26" class="combo"/>
-<text x="321" y="267" class="combo tap">⇧⎵</text>
+<text x="321" y="267" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <path d="M335,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="321" y="143" width="28" height="26" class="combo"/>
 <text x="335" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="371" y="93" width="28" height="26" class="combo"/>
 <text x="385" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="402" y="95" width="28" height="26" class="combo"/>
 <text x="416" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="453" y="49" width="28" height="26" class="combo"/>
 <text x="467" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="526" y="53" width="28" height="26" class="combo"/>
 <text x="540" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="590" y="79" width="28" height="26" class="combo"/>
 <text x="604" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="381" y="119" width="28" height="26" class="combo"/>
 <text x="395" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="391" y="145" width="28" height="26" class="combo"/>
 <text x="405" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="401" y="171" width="28" height="26" class="combo"/>
 <text x="415" y="184" class="combo tap">]}</text>
 </g>
@@ -774,98 +782,106 @@ text.right {
 <text x="63" y="110" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-3">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-5">
 <rect rx="6" ry="6" x="565" y="97" width="28" height="26" class="combo"/>
 <text x="579" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="496" y="78" width="28" height="26" class="combo"/>
 <text x="510" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-7">
 <rect rx="6" ry="6" x="437" y="98" width="28" height="26" class="combo"/>
 <text x="451" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-8">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="455" y="151" width="28" height="26" class="combo"/>
+<text x="469" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-15">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-16">
 <path d="M335,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="321" y="143" width="28" height="26" class="combo"/>
 <text x="335" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="371" y="93" width="28" height="26" class="combo"/>
 <text x="385" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="402" y="95" width="28" height="26" class="combo"/>
 <text x="416" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="453" y="49" width="28" height="26" class="combo"/>
 <text x="467" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="526" y="53" width="28" height="26" class="combo"/>
 <text x="540" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="590" y="79" width="28" height="26" class="combo"/>
 <text x="604" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="381" y="119" width="28" height="26" class="combo"/>
 <text x="395" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="391" y="145" width="28" height="26" class="combo"/>
 <text x="405" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="401" y="171" width="28" height="26" class="combo"/>
 <text x="415" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivouac34.yaml
+++ b/keymap-drawer/bivouac34.yaml
@@ -7,7 +7,7 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - ⌫
+  - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -29,10 +29,10 @@ layers:
   - {t: oO, type: high}
   - {t: yY, type: medium}
   - {t: wW, type: medium}
-  - {t: rR, h: ⇧, type: high}
+  - {t: rR, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   Naginata:
   - {t: ⎋, h: Small-kana}
   - {left: き, right: め}
@@ -143,23 +143,29 @@ combos:
 - p: [11, 10]
   k: ⎇
   l: [HD Promethium, Num + Nav]
+- p: [18, 19]
+  k: ⎇
+  l: [HD Promethium, Num + Nav]
 - p: [12, 11]
+  k: ⌃
+  l: [HD Promethium, Num + Nav]
+- p: [17, 18]
   k: ⌃
   l: [HD Promethium, Num + Nav]
 - p: [13, 12]
   k: ⌘
   l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [23, 22]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
+- p: [24, 25]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: vQ, type: low}
+  k: {t: qQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}
@@ -171,7 +177,7 @@ combos:
   k: {t: xX, type: low}
   l: [HD Promethium]
 - p: [28, 31]
-  k: ⇧⎵
+  k: ⇪
   l: [HD Promethium]
 - p: [0, 10]
   k: '`'

--- a/keymap-drawer/bivvy16d.svg
+++ b/keymap-drawer/bivvy16d.svg
@@ -156,6 +156,7 @@ text.right {
 <g transform="translate(463, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(515, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -228,11 +229,10 @@ text.right {
 <g transform="translate(245, 278) rotate(37.0)" class="key high keypos-24">
 <rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(453, 275) rotate(-37.0)" class="key high keypos-25">
 <rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(502, 186) rotate(-22.0)" class="key medium-high keypos-26">
@@ -342,120 +342,128 @@ text.right {
 <text x="63" y="110" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-7">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-9">
 <rect rx="6" ry="6" x="621" y="97" width="28" height="26" class="combo"/>
 <text x="635" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="552" y="78" width="28" height="26" class="combo"/>
 <text x="566" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-10">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-11">
 <rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
 <text x="507" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo low combopos-12">
-<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">vQ</text>
+<g class="combo combopos-12">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-13">
+<g class="combo combopos-13">
+<rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
+<text x="525" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-14">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-15">
 <rect rx="6" ry="6" x="539" y="24" width="28" height="26" class="combo low"/>
 <text x="553" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-16">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-17">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <path d="M349,276 l-72,1" class="combo"/>
 <path d="M349,276 l72,-1" class="combo"/>
 <rect rx="6" ry="6" x="335" y="263" width="28" height="26" class="combo"/>
-<text x="349" y="276" class="combo tap">⇧⎵</text>
+<text x="349" y="276" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
 <text x="391" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
 <text x="441" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
 <text x="472" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
 <text x="523" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
 <text x="596" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
 <text x="660" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
 <text x="451" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
 <text x="461" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
 <text x="471" y="184" class="combo tap">]}</text>
 </g>
@@ -874,98 +882,106 @@ text.right {
 <text x="63" y="110" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-3">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-5">
 <rect rx="6" ry="6" x="621" y="97" width="28" height="26" class="combo"/>
 <text x="635" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="552" y="78" width="28" height="26" class="combo"/>
 <text x="566" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-7">
 <rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
 <text x="507" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-8">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
+<text x="525" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-15">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-16">
 <path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
 <text x="391" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
 <text x="441" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
 <text x="472" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
 <text x="523" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
 <text x="596" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
 <text x="660" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
 <text x="451" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
 <text x="461" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
 <text x="471" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivvy16d.yaml
+++ b/keymap-drawer/bivvy16d.yaml
@@ -7,7 +7,7 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - ⌫
+  - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -25,8 +25,8 @@ layers:
   - {t: fF, type: medium}
   - {t: dD, type: medium-high}
   - {t: lL, type: medium-high}
-  - {t: rR, h: ⇧, type: high}
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: rR, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   - {t: uU, type: medium-high}
   - {t: oO, type: high}
   - {t: yY, type: medium}
@@ -167,23 +167,29 @@ combos:
 - p: [11, 10]
   k: ⎇
   l: [HD Promethium, Num + Nav]
+- p: [18, 19]
+  k: ⎇
+  l: [HD Promethium, Num + Nav]
 - p: [12, 11]
+  k: ⌃
+  l: [HD Promethium, Num + Nav]
+- p: [17, 18]
   k: ⌃
   l: [HD Promethium, Num + Nav]
 - p: [13, 12]
   k: ⌘
   l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [23, 22]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
+- p: [26, 27]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: vQ, type: low}
+  k: {t: qQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}
@@ -195,7 +201,7 @@ combos:
   k: {t: xX, type: low}
   l: [HD Promethium]
 - p: [24, 25]
-  k: ⇧⎵
+  k: ⇪
   l: [HD Promethium]
 - p: [0, 10]
   k: '`'

--- a/keymap-drawer/goldilocks32.svg
+++ b/keymap-drawer/goldilocks32.svg
@@ -156,6 +156,7 @@ text.right {
 <g transform="translate(407, 85) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(459, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -228,11 +229,10 @@ text.right {
 <g transform="translate(251, 274) rotate(37.0)" class="key high keypos-24">
 <rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(389, 274) rotate(-37.0)" class="key high keypos-25">
 <rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(445, 192) rotate(-22.0)" class="key medium-high keypos-26">
@@ -320,118 +320,126 @@ text.right {
 <text x="62" y="114" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-7">
-<rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
-<text x="131" y="93" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
-<text x="190" y="115" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-9">
 <rect rx="6" ry="6" x="564" y="101" width="28" height="26" class="combo"/>
 <text x="578" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
+<text x="131" y="93" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="495" y="80" width="28" height="26" class="combo"/>
 <text x="509" y="93" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-10">
+<rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
+<text x="190" y="115" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-11">
 <rect rx="6" ry="6" x="436" y="102" width="28" height="26" class="combo"/>
 <text x="450" y="115" class="combo tap">⌘</text>
 </g>
-<g class="combo low combopos-12">
-<rect rx="6" ry="6" x="193" y="47" width="28" height="26" class="combo low"/>
-<text x="207" y="60" class="combo low tap">vQ</text>
+<g class="combo combopos-12">
+<rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
+<text x="172" y="169" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-13">
+<g class="combo combopos-13">
+<rect rx="6" ry="6" x="454" y="156" width="28" height="26" class="combo"/>
+<text x="468" y="169" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-14">
+<rect rx="6" ry="6" x="193" y="47" width="28" height="26" class="combo low"/>
+<text x="207" y="60" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-15">
 <rect rx="6" ry="6" x="482" y="24" width="28" height="26" class="combo low"/>
 <text x="496" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-16">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-17">
 <rect rx="6" ry="6" x="105" y="136" width="28" height="26" class="combo low"/>
 <text x="119" y="149" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="306" y="261" width="28" height="26" class="combo"/>
-<text x="320" y="274" class="combo tap">⇧⎵</text>
+<text x="320" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
 <text x="37" y="98" class="combo tap">`</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
 <text x="101" y="67" class="combo tap">@</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
 <text x="174" y="63" class="combo tap">|</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
 <text x="224" y="112" class="combo tap">$</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
 <text x="255" y="110" class="combo tap">\</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
 <rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
 <text x="305" y="162" class="combo tap">%</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <path d="M335,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
 <rect rx="6" ry="6" x="321" y="149" width="28" height="26" class="combo"/>
 <text x="335" y="162" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="371" y="97" width="28" height="26" class="combo"/>
 <text x="385" y="110" class="combo tap">/</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="402" y="99" width="28" height="26" class="combo"/>
 <text x="416" y="112" class="combo tap">?</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="452" y="50" width="28" height="26" class="combo"/>
 <text x="466" y="63" class="combo tap">#</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="525" y="54" width="28" height="26" class="combo"/>
 <text x="539" y="67" class="combo tap">!</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="589" y="85" width="28" height="26" class="combo"/>
 <text x="603" y="98" class="combo tap">~</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
 <text x="245" y="137" class="combo tap">{</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="381" y="124" width="28" height="26" class="combo"/>
 <text x="395" y="137" class="combo tap">}</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
 <text x="236" y="164" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="390" y="151" width="28" height="26" class="combo"/>
 <text x="404" y="164" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
 <text x="226" y="191" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="400" y="178" width="28" height="26" class="combo"/>
 <text x="414" y="191" class="combo tap">]}</text>
 </g>
@@ -806,98 +814,106 @@ text.right {
 <text x="62" y="114" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-3">
-<rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
-<text x="131" y="93" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
-<text x="190" y="115" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-5">
 <rect rx="6" ry="6" x="564" y="101" width="28" height="26" class="combo"/>
 <text x="578" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
+<text x="131" y="93" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="495" y="80" width="28" height="26" class="combo"/>
 <text x="509" y="93" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
+<text x="190" y="115" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-7">
 <rect rx="6" ry="6" x="436" y="102" width="28" height="26" class="combo"/>
 <text x="450" y="115" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-8">
+<rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
+<text x="172" y="169" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="454" y="156" width="28" height="26" class="combo"/>
+<text x="468" y="169" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
 <text x="37" y="98" class="combo tap">`</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
 <text x="101" y="67" class="combo tap">@</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
 <text x="174" y="63" class="combo tap">|</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
 <text x="224" y="112" class="combo tap">$</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
 <text x="255" y="110" class="combo tap">\</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-15">
 <path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
 <rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
 <text x="305" y="162" class="combo tap">%</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-16">
 <path d="M335,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
 <rect rx="6" ry="6" x="321" y="149" width="28" height="26" class="combo"/>
 <text x="335" y="162" class="combo tap">^</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="371" y="97" width="28" height="26" class="combo"/>
 <text x="385" y="110" class="combo tap">/</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="402" y="99" width="28" height="26" class="combo"/>
 <text x="416" y="112" class="combo tap">?</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="452" y="50" width="28" height="26" class="combo"/>
 <text x="466" y="63" class="combo tap">#</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="525" y="54" width="28" height="26" class="combo"/>
 <text x="539" y="67" class="combo tap">!</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="589" y="85" width="28" height="26" class="combo"/>
 <text x="603" y="98" class="combo tap">~</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
 <text x="245" y="137" class="combo tap">{</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="381" y="124" width="28" height="26" class="combo"/>
 <text x="395" y="137" class="combo tap">}</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
 <text x="236" y="164" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="390" y="151" width="28" height="26" class="combo"/>
 <text x="404" y="164" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
 <text x="226" y="191" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="400" y="178" width="28" height="26" class="combo"/>
 <text x="414" y="191" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/goldilocks32.yaml
+++ b/keymap-drawer/goldilocks32.yaml
@@ -7,7 +7,7 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - ⌫
+  - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -25,8 +25,8 @@ layers:
   - {t: fF, type: medium}
   - {t: dD, type: medium-high}
   - {t: lL, type: medium-high}
-  - {t: rR, h: ⇧, type: high}
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: rR, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   - {t: uU, type: medium-high}
   - {t: oO, type: high}
   - {t: yY, type: medium}
@@ -152,23 +152,29 @@ combos:
 - p: [11, 10]
   k: ⎇
   l: [HD Promethium, Num + Nav]
+- p: [18, 19]
+  k: ⎇
+  l: [HD Promethium, Num + Nav]
 - p: [12, 11]
+  k: ⌃
+  l: [HD Promethium, Num + Nav]
+- p: [17, 18]
   k: ⌃
   l: [HD Promethium, Num + Nav]
 - p: [13, 12]
   k: ⌘
   l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [23, 22]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
+- p: [26, 27]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: vQ, type: low}
+  k: {t: qQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}
@@ -180,7 +186,7 @@ combos:
   k: {t: xX, type: low}
   l: [HD Promethium]
 - p: [24, 25]
-  k: ⇧⎵
+  k: ⇪
   l: [HD Promethium]
 - p: [0, 10]
   k: '`'

--- a/keymap-drawer/hesse.svg
+++ b/keymap-drawer/hesse.svg
@@ -156,6 +156,7 @@ text.right {
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -256,7 +257,6 @@ text.right {
 <g transform="translate(199, 274) rotate(37.0)" class="key high keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -269,7 +269,7 @@ text.right {
 </g>
 <g transform="translate(521, 274) rotate(-37.0)" class="key high keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(576, 241) rotate(-22.0)" class="key keypos-35">
@@ -328,120 +328,128 @@ text.right {
 <text x="63" y="106" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-7">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-9">
 <rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
 <text x="657" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
 <text x="588" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-10">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-11">
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo low combopos-12">
-<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">vQ</text>
+<g class="combo combopos-12">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-13">
+<g class="combo combopos-13">
+<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
+<text x="547" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-14">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-15">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
 <text x="575" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-16">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-17">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <path d="M360,274 l-142,0" class="combo"/>
 <path d="M360,274 l142,0" class="combo"/>
 <rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
-<text x="360" y="274" class="combo tap">⇧⎵</text>
+<text x="360" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
@@ -828,123 +836,131 @@ text.right {
 <text x="63" y="106" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-3">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-5">
 <rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
 <text x="657" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
 <text x="588" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-7">
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-8">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
+<text x="547" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-15">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-16">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="53" y="37" width="28" height="26" class="combo"/>
 <text x="67" y="50" class="combo tap">BT</text>
 <text x="67" y="61" class="combo hold">0</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo"/>
 <text x="144" y="37" class="combo tap">BT</text>
 <text x="144" y="48" class="combo hold">1</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo"/>
 <text x="209" y="59" class="combo tap">BT</text>
 <text x="209" y="70" class="combo hold">2</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="497" y="46" width="28" height="26" class="combo"/>
 <text x="511" y="59" class="combo tap">
 <tspan x="511" dy="-0.6em">BT</tspan><tspan x="511" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo"/>
 <text x="575" y="37" class="combo tap">
 <tspan x="575" dy="-0.6em">BT</tspan><tspan x="575" dy="1.2em">…</tspan>

--- a/keymap-drawer/hesse.yaml
+++ b/keymap-drawer/hesse.yaml
@@ -7,7 +7,7 @@ layers:
   - {t: mM, type: medium}
   - {t: xX, type: low}
   - {t: '/?', type: low}
-  - ⌫
+  - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -32,10 +32,10 @@ layers:
   - {t: yY, type: medium}
   - {t: wW, type: medium}
   - ↹
-  - {t: rR, h: ⇧, type: high}
+  - {t: rR, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   - Num + Nav
   Naginata:
   - {t: ⎋, h: Small-kana}
@@ -155,23 +155,29 @@ combos:
 - p: [11, 10]
   k: ⎇
   l: [HD Promethium, Num + Nav]
+- p: [18, 19]
+  k: ⎇
+  l: [HD Promethium, Num + Nav]
 - p: [12, 11]
+  k: ⌃
+  l: [HD Promethium, Num + Nav]
+- p: [17, 18]
   k: ⌃
   l: [HD Promethium, Num + Nav]
 - p: [13, 12]
   k: ⌘
   l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [23, 22]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
+- p: [26, 27]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: vQ, type: low}
+  k: {t: qQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}
@@ -183,7 +189,7 @@ combos:
   k: {t: xX, type: low}
   l: [HD Promethium]
 - p: [31, 34]
-  k: ⇧⎵
+  k: ⇪
   l: [HD Promethium]
 - p: [0, 10]
   k: '`'

--- a/keymap-drawer/slump52.svg
+++ b/keymap-drawer/slump52.svg
@@ -160,6 +160,7 @@ text.right {
 <g transform="translate(437, 77) rotate(-25.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(491, 54) rotate(-21.0)" class="key medium-low keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -260,11 +261,10 @@ text.right {
 <g transform="translate(248, 228) rotate(25.0)" class="key high keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(446, 228) rotate(-25.0)" class="key high keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(485, 179) rotate(-25.0)" class="key medium-high keypos-34">
@@ -302,7 +302,6 @@ text.right {
 <g transform="translate(300, 258) rotate(35.0)" class="key high keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(347, 297) rotate(-45.0)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -311,7 +310,7 @@ text.right {
 </g>
 <g transform="translate(393, 258) rotate(-35.0)" class="key high keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(547, 301) rotate(-11.5)" class="key keypos-45">
@@ -391,118 +390,126 @@ text.right {
 <text x="65" y="114" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-7">
-<rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
-<text x="140" y="97" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
-<text x="205" y="116" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-9">
 <rect rx="6" ry="6" x="614" y="101" width="28" height="26" class="combo"/>
 <text x="628" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
+<text x="140" y="97" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="540" y="84" width="28" height="26" class="combo"/>
 <text x="554" y="97" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-10">
+<rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
+<text x="205" y="116" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-11">
 <rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
 <text x="489" y="116" class="combo tap">⌘</text>
 </g>
-<g class="combo low combopos-12">
-<rect rx="6" ry="6" x="216" y="53" width="28" height="26" class="combo low"/>
-<text x="230" y="66" class="combo low tap">vQ</text>
+<g class="combo combopos-12">
+<rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
+<text x="180" y="168" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-13">
+<g class="combo combopos-13">
+<rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
+<text x="514" y="168" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-14">
+<rect rx="6" ry="6" x="216" y="53" width="28" height="26" class="combo low"/>
+<text x="230" y="66" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-15">
 <rect rx="6" ry="6" x="505" y="33" width="28" height="26" class="combo low"/>
 <text x="519" y="46" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-16">
 <rect rx="6" ry="6" x="160" y="33" width="28" height="26" class="combo low"/>
 <text x="174" y="46" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-17">
 <rect rx="6" ry="6" x="106" y="137" width="28" height="26" class="combo low"/>
 <text x="120" y="150" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="333" y="245" width="28" height="26" class="combo"/>
-<text x="347" y="258" class="combo tap">⇧⎵</text>
+<text x="347" y="258" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
 <text x="28" y="112" class="combo tap">`</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
 <text x="124" y="63" class="combo tap">@</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
 <text x="190" y="80" class="combo tap">|</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
 <text x="244" y="102" class="combo tap">$</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
 <text x="276" y="102" class="combo tap">\</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
 <rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
 <text x="324" y="151" class="combo tap">%</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
 <rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
 <text x="370" y="151" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
 <text x="418" y="102" class="combo tap">/</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
 <text x="449" y="102" class="combo tap">?</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
 <text x="504" y="80" class="combo tap">#</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
 <text x="570" y="63" class="combo tap">!</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
 <text x="666" y="112" class="combo tap">~</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
 <text x="264" y="127" class="combo tap">{</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
 <text x="430" y="127" class="combo tap">}</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
 <text x="252" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
 <text x="442" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
 <text x="240" y="178" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
 <text x="454" y="178" class="combo tap">]}</text>
 </g>
@@ -1021,98 +1028,106 @@ text.right {
 <text x="65" y="114" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-3">
-<rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
-<text x="140" y="97" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
-<text x="205" y="116" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-5">
 <rect rx="6" ry="6" x="614" y="101" width="28" height="26" class="combo"/>
 <text x="628" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
+<text x="140" y="97" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="540" y="84" width="28" height="26" class="combo"/>
 <text x="554" y="97" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
+<text x="205" y="116" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-7">
 <rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
 <text x="489" y="116" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-8">
+<rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
+<text x="180" y="168" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
+<text x="514" y="168" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
 <text x="28" y="112" class="combo tap">`</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
 <text x="124" y="63" class="combo tap">@</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
 <text x="190" y="80" class="combo tap">|</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
 <text x="244" y="102" class="combo tap">$</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
 <text x="276" y="102" class="combo tap">\</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-15">
 <path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
 <rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
 <text x="324" y="151" class="combo tap">%</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-16">
 <path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
 <rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
 <text x="370" y="151" class="combo tap">^</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
 <text x="418" y="102" class="combo tap">/</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
 <text x="449" y="102" class="combo tap">?</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
 <text x="504" y="80" class="combo tap">#</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
 <text x="570" y="63" class="combo tap">!</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
 <text x="666" y="112" class="combo tap">~</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
 <text x="264" y="127" class="combo tap">{</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
 <text x="430" y="127" class="combo tap">}</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
 <text x="252" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
 <text x="442" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
 <text x="240" y="178" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
 <text x="454" y="178" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/slump52.yaml
+++ b/keymap-drawer/slump52.yaml
@@ -8,7 +8,7 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - ⌫
+  - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -33,8 +33,8 @@ layers:
   - {t: fF, type: medium}
   - {t: dD, type: medium-high}
   - {t: lL, type: medium-high}
-  - {t: rR, h: ⇧, type: high}
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: rR, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   - {t: uU, type: medium-high}
   - {t: oO, type: high}
   - {t: yY, type: medium}
@@ -43,9 +43,9 @@ layers:
   - '2'
   - '3'
   - {t: bB, type: medium-low}
-  - {t: rR, h: ⇧, type: high}
+  - {t: rR, type: high}
   - {t: ⌫, h: ⇧}
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   - ←
   - ↓
   - ↑
@@ -203,23 +203,29 @@ combos:
 - p: [16, 28]
   k: ⎇
   l: [HD Promethium, Num + Nav]
+- p: [23, 37]
+  k: ⎇
+  l: [HD Promethium, Num + Nav]
 - p: [17, 16]
+  k: ⌃
+  l: [HD Promethium, Num + Nav]
+- p: [22, 23]
   k: ⌃
   l: [HD Promethium, Num + Nav]
 - p: [18, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
-- p: [23, 37]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [22, 23]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
 - p: [21, 22]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [31, 30]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
+- p: [34, 35]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
 - p: [4, 3]
-  k: {t: vQ, type: low}
+  k: {t: qQ, type: low}
   l: [HD Promethium]
 - p: [8, 9]
   k: {t: zZ, type: low}
@@ -231,7 +237,7 @@ combos:
   k: {t: xX, type: low}
   l: [HD Promethium]
 - p: [42, 44]
-  k: ⇧⎵
+  k: ⇪
   l: [HD Promethium]
 - p: [15, 28]
   k: '`'

--- a/keymap-drawer/tc36k.svg
+++ b/keymap-drawer/tc36k.svg
@@ -156,6 +156,7 @@ text.right {
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -256,7 +257,6 @@ text.right {
 <g transform="translate(199, 274) rotate(37.0)" class="key high keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
-<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -269,7 +269,7 @@ text.right {
 </g>
 <g transform="translate(521, 274) rotate(-37.0)" class="key high keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="0" class="key high tap">⎵</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(576, 241) rotate(-22.0)" class="key keypos-35">
@@ -328,120 +328,128 @@ text.right {
 <text x="63" y="106" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-7">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-9">
 <rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
 <text x="657" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
 <text x="588" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-10">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-11">
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo low combopos-12">
-<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">vQ</text>
+<g class="combo combopos-12">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-13">
+<g class="combo combopos-13">
+<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
+<text x="547" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-14">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-15">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
 <text x="575" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-16">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-17">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <path d="M360,274 l-142,0" class="combo"/>
 <path d="M360,274 l142,0" class="combo"/>
 <rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
-<text x="360" y="274" class="combo tap">⇧⎵</text>
+<text x="360" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
@@ -828,98 +836,106 @@ text.right {
 <text x="63" y="106" class="combo tap">⎇</text>
 </g>
 <g class="combo combopos-3">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-5">
 <rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
 <text x="657" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
 <text x="588" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-7">
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
 <g class="combo combopos-8">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
+<text x="547" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-15">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-16">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/tc36k.yaml
+++ b/keymap-drawer/tc36k.yaml
@@ -7,7 +7,7 @@ layers:
   - {t: mM, type: medium}
   - {t: xX, type: low}
   - {t: '/?', type: low}
-  - ⌫
+  - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -32,10 +32,10 @@ layers:
   - {t: yY, type: medium}
   - {t: wW, type: medium}
   - ↹
-  - {t: rR, h: ⇧, type: high}
+  - {t: rR, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: ⎵, h: Num+Nav, type: high}
   - Num + Nav
   Naginata:
   - {t: ⎋, h: Small-kana}
@@ -155,23 +155,29 @@ combos:
 - p: [11, 10]
   k: ⎇
   l: [HD Promethium, Num + Nav]
+- p: [18, 19]
+  k: ⎇
+  l: [HD Promethium, Num + Nav]
 - p: [12, 11]
+  k: ⌃
+  l: [HD Promethium, Num + Nav]
+- p: [17, 18]
   k: ⌃
   l: [HD Promethium, Num + Nav]
 - p: [13, 12]
   k: ⌘
   l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [23, 22]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
+- p: [26, 27]
+  k: ⇧
+  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: vQ, type: low}
+  k: {t: qQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}
@@ -183,7 +189,7 @@ combos:
   k: {t: xX, type: low}
   l: [HD Promethium]
 - p: [31, 34]
-  k: ⇧⎵
+  k: ⇪
   l: [HD Promethium]
 - p: [0, 10]
   k: '`'

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -133,6 +133,7 @@ parse_config:
     KP_PLUS: '+'
     KP_MINUS: '-'
   zmk_combos:
+    caps_word_combo: {'key': '⇪'}
     combo_studio_unlock: {'key': 'Studio Unlock', 'align': 'top', 'offset': 0.3, 'width': 50}
     combo_bootloader: {'key': 'Boot loader', 'width': 50}
     tab_combo: {'align': 'bottom', 'offset': -0.02, 'slide': -0.5, 'height': 15}

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -133,7 +133,6 @@ parse_config:
     KP_PLUS: '+'
     KP_MINUS: '-'
   zmk_combos:
-    #shift_space_combo: {'key': '⇧⎵', 'align': 'top'}
     combo_studio_unlock: {'key': 'Studio Unlock', 'align': 'top', 'offset': 0.3, 'width': 50}
     combo_bootloader: {'key': 'Boot loader', 'width': 50}
     tab_combo: {'align': 'bottom', 'offset': -0.02, 'slide': -0.5, 'height': 15}
@@ -195,8 +194,6 @@ parse_config:
     '&kp EQUAL': {'t': '=+', 'type': 'low'}
     '&kp SPACE': {'t': '⎵', 'type': 'high'}
     '&blt NUM_NAV SPACE': {'t': '⎵', 'h': 'Num+Nav', 'type': 'high'}
-    '&bmt LSHFT R': {'t': 'rR', 'h': '⇧', 'type': 'high'}
-    '&space_R_layer NUM_NAV 0': {'t': '⎵R', 'h': 'Num+Nav', 'type': 'high'}
     # And again for auto-shift:
     'AS(A)': {'t': 'aA', 'type': 'high'}
     'AS(B)': {'t': 'bB', 'type': 'medium-low'}


### PR DESCRIPTION
This drops the capital R workarounds, restores auto-shift, and adds caps word as the home thumbs combo.

This means any capital can be typed with a long tap, or peceeding it with a magic comma. And strings of capitals like QWERTY are easily done with the two-thumb combo.

Shift for selection remains on the left thumb of the nav/numbers layer. This is possible but fiddly with the mouse in the right hand (move the left hand, or engage shift before move right hand to the mouse).

Note PR #15 originally added auto-shift (long tap for shifted forms like capitals), but I dropped it in #24 - see notes on #20.