### PR TITLE
Autoshift & HRM combos --> Thumb-shift and Timeless HRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ of word, and forward to start of next word in Vim or Helix.
 Most of the symbols are 2-key vertical combos, the brackets are 2-key horizontal
 combos (open on the left hand, close on the right).
 
-This has *Auto Shift* setup, meaning a long tap on the base layer letters and
-symbols gives the capital or shifted form. I am also trying out *Magic Comma Shift*
-whereby typing comma then a letter will give the capital version of the letter -
-but typing comma and space just works as usual.
-
 I wanted to be able to use this on my laptop too - achieved with [custom Karabiner-Elements
 rules](https://codeberg.org/peterjc/kana-chording-ke/src/branch/main/hands-down-on-jis-macbook)
 (see this [blog post](https://blastedbio.blogspot.com/2025/05/what-have-you-done-to-your-keyboard.html)).
@@ -46,6 +41,9 @@ hand has navigation keys including an inverted-tee set of cursors at the Qwerty
 JKIL position inspired by [Dreymar's Extend layer](https://dreymar.colemak.org/layers-extend.html).
 The left hand has a number-pad, with 123 at the top like a mobile phone (since
 in a traditional keyboard 123 are about there).
+
+I am trying *Magic Comma Shift* whereby typing comma then a letter will give the
+capital version of the letter - but typing comma and space just works as usual.
 
 ## Split 3x5_3 aka 33333+3 Layout with 36 keys
 

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -208,10 +208,12 @@
             quick-tap-ms = <175>;
             bindings = <&kp>, <&kp>;
         };
+        /* Don't use this for alt or GUI on Windows; shift and ctrl fine */
         bmt: balanced_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
+            hold-while-undecided;
             tapping-term-ms = <300>;
             quick-tap-ms = <250>;
             bindings = <&kp>, <&kp>;
@@ -312,7 +314,7 @@
                 &kp ESCAPE,   &kp P,       &kp G,        &kp M,       &kp X,            &kp SLASH,   &kp BSPC,    &xquote,      &kp MINUS,   &kp EQUAL, \
                 &hml RSHFT S, &hml LALT N, &hml LCTRL T, &hml LGUI H, &kp K,            &dot_colon,  &hmr LGUI A, &hmr LCTRL E, &hmr LALT I, &hmr RSHFT C, \
                 &hml RSHFT B, &hml RALT F, &hml RCTRL D, &hml RGUI L, &kp J,            &comma_semi, &hmr RGUI U, &hmr RCTRL O, &hmr RALT Y, &hmr RSHFT W, \
-                                           &kp TAB,    &hpmt LSHFT R, &hpmt LSHFT BSPC, &kp RSHFT,   &space_R_layer NUM_NAV 0, &mo NUM_NAV \
+                                           &kp TAB,     &bmt LSHFT R, &hpmt LSHFT BSPC, &kp RSHFT,   &space_R_layer NUM_NAV 0, &mo NUM_NAV \
             )>;
         };
 

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -409,62 +409,6 @@
             require-prior-idle-ms = <125>;
         };
 
-        // 2-key horizontal home-row combos for modifiers
-        left_alt_combo {
-            bindings = <&kp LALT>;
-            key-positions = <LM3 LM4>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-        };
-        right_alt_combo {
-            bindings = <&kp RALT>;
-            key-positions = <RM3 RM4>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-        };
-        left_ctrl_combo {
-            bindings = <&kp LCTRL>;
-            key-positions = <LM2 LM3>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-        };
-        right_ctrl_combo {
-            bindings = <&kp RCTRL>;
-            key-positions = <RM2 RM3>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-        };
-        left_gui_combo {
-            bindings = <&kp LGUI>;
-            key-positions = <LM1 LM2>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-            timeout-ms = <40>;
-        };
-        right_gui_combo {
-            bindings = <&kp RGUI>;
-            key-positions = <RM1 RM2>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-            timeout-ms = <40>;
-        };
-
-        // 2-key horizontal bottom-row combos for shift
-        left_shift_combo {
-            bindings = <&kp LSHFT>;
-            key-positions = <LB1 LB2>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-            timeout-ms = <40>;
-        };
-        right_shift_combo {
-            bindings = <&kp RSHFT>;
-            key-positions = <RB1 RB2>;
-            layers = <DEFAULT NUM_NAV>;
-            require-prior-idle-ms = <250>;
-            timeout-ms = <40>;
-        };
-
         // 2-key horizontal combos for rare letters
         q_combo {
             bindings = <&kp Q>;

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -31,10 +31,6 @@
 #define NAGINATA 1
 #define NUM_NAV 2
 
-#define my_linger_term 300// linger mod-tap trigger time window
-
-#define AS(keycode) &as LS(keycode) keycode     // Autoshift Macro
-
 / {
     macros {
         // To switch to Japanese mode, this sends what Karabiner-Elements sees
@@ -156,15 +152,6 @@
             // (Staying with default limit of 32 definitions)
         };
 
-        as: auto_shift {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            tapping_term_ms = <my_linger_term>;
-            quick_tap_ms = <250>;
-            flavor = "tap-preferred";
-            bindings = <&kp>, <&kp>;
-        };
-        /* Don't use this for alt or GUI on Windows; shift and ctrl fine */
         hpmt: hold_preferred_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
@@ -204,7 +191,7 @@
         xquote: override_shift_quote {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&as LS(N2) SQT>, <&kp N2>;
+            bindings = <&kp SQT>, <&kp N2>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
             // need to keep shift, and anything else too:
             keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
@@ -214,38 +201,29 @@
         open_par_lt: open_par_lt {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&as LESS_THAN LEFT_PARENTHESIS>, <&kp LESS_THAN>;
+            bindings = <&kp LEFT_PARENTHESIS>, <&kp LESS_THAN>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
         };
         close_par_gt: close_par_gt {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&as GREATER_THAN RIGHT_PARENTHESIS>, <&kp GREATER_THAN>;
+            bindings = <&kp RIGHT_PARENTHESIS>, <&kp GREATER_THAN>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
         };
 
         dot_colon: dot_colon {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&as COLON DOT>, <&kp COLON>;
+            bindings = <&kp DOT>, <&kp COLON>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
             // need to keep shift, and anything else too:
             keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
         };
 
-        magic_comma_ht: magic_comma_ht {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            tapping_term_ms = <my_linger_term>;
-            quick_tap_ms = <250>;
-            flavor = "tap-preferred";
-            bindings = <&kp>, <&magic_comma_shift>;
-        };
-
         comma_semi: comma_semi {
             compatible = "zmk,behavior-mod-morph";
             #binding-cells = <0>;
-            bindings = <&magic_comma_ht SEMI 0>, <&kp SEMI>;
+            bindings = <&magic_comma_shift>, <&kp SEMI>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
             // do NOT want to keep shift active, but anything else is fine:
             keep-mods = <(MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
@@ -261,10 +239,10 @@
         default_layer {
             display-name = "HD Promethium";
             bindings = <LAYER_FROM36( \
-                &kp ESCAPE, AS(P), AS(G), AS(M), AS(X),      AS(SLASH),   AS(BSPC), &xquote, AS(MINUS), AS(EQUAL), \
-                AS(S),      AS(N), AS(T), AS(H), AS(K),      &dot_colon,  AS(A),    AS(E),   AS(I),     AS(C),  \
-                AS(B),      AS(F), AS(D), AS(L), AS(J),      &comma_semi, AS(U),    AS(O),   AS(Y),     AS(W),  \
-                      &kp TAB, AS(R), &hpmt LSHFT BSPC,      &kp RSHFT, &blt NUM_NAV SPACE, &mo NUM_NAV \
+                &kp ESCAPE, &kp P, &kp G, &kp M, &kp X,      &kp SLASH,   &kp BSPC, &xquote, &kp MINUS, &kp EQUAL, \
+                &kp S,      &kp N, &kp T, &kp H, &kp K,      &dot_colon,  &kp A,    &kp E,   &kp I,     &kp C,  \
+                &kp B,      &kp F, &kp D, &kp L, &kp J,      &comma_semi, &kp U,    &kp O,   &kp Y,     &kp W,  \
+                &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC,     &kp RSHFT, &blt NUM_NAV SPACE, &mo NUM_NAV \
             )>;
         };
 
@@ -442,28 +420,28 @@
 
         // 2-key horizontal combos for rare letters
         q_combo {
-            bindings = <AS(Q)>;
+            bindings = <&kp Q>;
             key-positions = <LT1 LT2>;
             layers = <DEFAULT>;
             timeout-ms = <100>;
         };
 
         z_combo {
-            bindings = <AS(Z)>;
+            bindings = <&kp Z>;
             key-positions = <RT2 RT3>;
             layers = <DEFAULT>;
             timeout-ms = <75>;
         };
 
         v_combo {
-            bindings = <AS(V)>;
+            bindings = <&kp V>;
             key-positions = <LT2 LT3>;
             layers = <DEFAULT>;
             timeout-ms = <75>;
         };
 
         x_combo {
-            bindings = <AS(X)>;
+            bindings = <&kp X>;
             key-positions = <LB2 LB3>;
             layers = <DEFAULT>;
             timeout-ms = <75>;
@@ -565,7 +543,7 @@
             layers = <DEFAULT NUM_NAV>;
         };
 
-        // 2-key horizontal combos for {}, can instead use shift with the [] combos:
+        // 2-key horizontal combos for {}, can also use shift with [] combos:
 #ifndef LT0
         open_curly {
             bindings = <&kp LEFT_BRACE>;
@@ -621,13 +599,13 @@
 
         // 2-key horizontal combos for [] with shifted form {}
         open_square_curly {
-            bindings = <AS(LEFT_BRACKET)>;
+            bindings = <&kp LEFT_BRACKET>;
             key-positions = <LB0 LB1>;
             layers = <DEFAULT NUM_NAV>;
         };
 
         close_square_curly {
-            bindings = <AS(RIGHT_BRACKET)>;
+            bindings = <&kp RIGHT_BRACKET>;
             key-positions = <RB0 RB1>;
             layers = <DEFAULT NUM_NAV>;
         };

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -233,6 +233,29 @@
             bindings = <&mo>, <&kp>;
         };
 
+        // Right thumb:
+        // * tap --> space
+        // * left-shift + tap --> capital R (as would hold left thumb 'r' for shift)
+        // * right-shift + tap --> shift+space (for reverse pagination)
+        // * hold --> layer
+        space_R: space_R {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp SPACE>, <&kp R>;
+            mods = <MOD_LSFT>;
+            // need to keep shift, and anything else too:
+            keep-mods = <(MOD_LSFT|MOD_RSFT|MOD_LCTL|MOD_RCTL|MOD_LALT|MOD_RALT|MOD_LGUI|MOD_RGUI)>;
+        };
+        space_R_layer: space_R_layer {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <300>;
+            quick-tap-ms = <250>;
+            bindings = <&mo>, <&space_R>;
+            display-name = "Space/R/Layer";
+        };
+
         // make shift+quote give double-quote like ANSI or Apple UK
         // when host setup with British layout (would be @-sign)
         xquote: override_shift_quote {
@@ -287,9 +310,9 @@
             display-name = "HD Promethium";
             bindings = <LAYER_FROM36( \
                 &kp ESCAPE,   &kp P,       &kp G,        &kp M,       &kp X,            &kp SLASH,   &kp BSPC,    &xquote,      &kp MINUS,   &kp EQUAL, \
-                &hml LSHFT S, &hml LALT N, &hml LCTRL T, &hml LGUI H, &kp K,            &dot_colon,  &hmr LGUI A, &hmr LCTRL E, &hmr LALT I, &hmr LSHFT C, \
+                &hml RSHFT S, &hml LALT N, &hml LCTRL T, &hml LGUI H, &kp K,            &dot_colon,  &hmr LGUI A, &hmr LCTRL E, &hmr LALT I, &hmr RSHFT C, \
                 &hml RSHFT B, &hml RALT F, &hml RCTRL D, &hml RGUI L, &kp J,            &comma_semi, &hmr RGUI U, &hmr RCTRL O, &hmr RALT Y, &hmr RSHFT W, \
-                                           &kp TAB,    &hpmt LSHFT R, &hpmt LSHFT BSPC, &kp RSHFT,   &blt NUM_NAV SPACE, &mo NUM_NAV \
+                                           &kp TAB,    &hpmt LSHFT R, &hpmt LSHFT BSPC, &kp RSHFT,   &space_R_layer NUM_NAV 0, &mo NUM_NAV \
             )>;
         };
 
@@ -327,7 +350,7 @@
             display-name = "Num + Nav";
             bindings = <LAYER_FROM36( \
                 &kp KP_DIVIDE,          &kp N1,       &kp N2,        &kp N3,         &kp KP_EQUAL, &kp ESCAPE, &kp BSPC,     &kp UP,     &kp UNDERSCORE, &kp C_PLAY_PAUSE, \
-                &hml LSHFT KP_MULTIPLY, &hml LALT N4, &hml LCTRL N5, &hml LGUI N6,   &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,      &hmr LSHFT C_VOLUME_UP, \
+                &hml RSHFT KP_MULTIPLY, &hml LALT N4, &hml LCTRL N5, &hml LGUI N6,   &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,      &hmr RSHFT C_VOLUME_UP, \
                 &hml RSHFT DOT,         &hml RALT N7, &hml RCTRL N8, &hml RGUI N9,   &kp KP_MINUS, &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT),  &hmr RSHFT C_VOLUME_DOWN, \
                                                       &trans,        &hpmt LSHFT N0, &trans,       &trans,     &trans,       &trans \
             )>;

--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -31,6 +31,28 @@
 #define NAGINATA 1
 #define NUM_NAV 2
 
+#ifndef LT0
+  // Have reduced 33332 blocks like some Hummingbird keyboards
+  #define KEYS_L LT1 LT2 LT3 LT4 LM0 LM1 LM2 LM3 LM4 LB0 LB1 LB2 LB3 LB4
+  #define KEYS_R RT1 RT2 RT3 RT4 RM0 RM1 RM2 RM3 RM4 RB0 RB1 RB2 RB3 RB4
+#else
+  // Have the full 33333 or 3x5 blocks
+  #define KEYS_L LT0 LT1 LT2 LT3 LT4 LM0 LM1 LM2 LM3 LM4 LB0 LB1 LB2 LB3 LB4
+  #define KEYS_R RT0 RT1 RT2 RT3 RT4 RM0 RM1 RM2 RM3 RM4 RB0 RB1 RB2 RB3 RB4
+#endif
+
+#ifndef THUMBS
+#ifndef LH0
+  #define THUMBS LH1 RH1 // Only two thumb-keys (one per thumb)
+#else
+#ifndef LH2
+  #define THUMBS LH1 LH0 RH0 RH1 // Four thumb-keys (two per thumb)
+#else
+  #define THUMBS LH2 LH1 LH0 RH0 RH1 RH2 // At least six thumb-keys
+#endif
+#endif
+#endif
+
 / {
     macros {
         // To switch to Japanese mode, this sends what Karabiner-Elements sees
@@ -152,6 +174,31 @@
             // (Staying with default limit of 32 definitions)
         };
 
+        /* Left-hand HRMs. */
+        hml: home_row_mod_left {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <280>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <150>;
+            bindings = <&kp>, <&kp>;
+            hold-trigger-key-positions = <KEYS_R THUMBS>;
+            hold-trigger-on-release;
+        };
+        /* Right-hand HRMs. */
+        hmr: home_row_mod_right {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <280>;
+            quick-tap-ms = <175>;
+            require-prior-idle-ms = <150>;
+            bindings = <&kp>, <&kp>;
+            hold-trigger-key-positions = <KEYS_L THUMBS>;
+            hold-trigger-on-release;
+        };
+        /* Don't use this for alt or GUI on Windows; shift and ctrl fine */
         hpmt: hold_preferred_mod_tap_qt {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
@@ -239,10 +286,10 @@
         default_layer {
             display-name = "HD Promethium";
             bindings = <LAYER_FROM36( \
-                &kp ESCAPE, &kp P, &kp G, &kp M, &kp X,      &kp SLASH,   &kp BSPC, &xquote, &kp MINUS, &kp EQUAL, \
-                &kp S,      &kp N, &kp T, &kp H, &kp K,      &dot_colon,  &kp A,    &kp E,   &kp I,     &kp C,  \
-                &kp B,      &kp F, &kp D, &kp L, &kp J,      &comma_semi, &kp U,    &kp O,   &kp Y,     &kp W,  \
-                &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC,     &kp RSHFT, &blt NUM_NAV SPACE, &mo NUM_NAV \
+                &kp ESCAPE,   &kp P,       &kp G,        &kp M,       &kp X,            &kp SLASH,   &kp BSPC,    &xquote,      &kp MINUS,   &kp EQUAL, \
+                &hml LSHFT S, &hml LALT N, &hml LCTRL T, &hml LGUI H, &kp K,            &dot_colon,  &hmr LGUI A, &hmr LCTRL E, &hmr LALT I, &hmr LSHFT C, \
+                &hml RSHFT B, &hml RALT F, &hml RCTRL D, &hml RGUI L, &kp J,            &comma_semi, &hmr RGUI U, &hmr RCTRL O, &hmr RALT Y, &hmr RSHFT W, \
+                                           &kp TAB,    &hpmt LSHFT R, &hpmt LSHFT BSPC, &kp RSHFT,   &blt NUM_NAV SPACE, &mo NUM_NAV \
             )>;
         };
 
@@ -279,10 +326,10 @@
         num_nav_layer {
             display-name = "Num + Nav";
             bindings = <LAYER_FROM36( \
-                &kp KP_DIVIDE,   &kp N1, &kp N2, &kp N3, &kp KP_EQUAL, &kp ESCAPE, &kp BSPC,     &kp UP,     &kp UNDERSCORE, &kp C_PLAY_PAUSE, \
-                &kp KP_MULTIPLY, &kp N4, &kp N5, &kp N6, &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,      &kp C_VOLUME_UP, \
-                &kp DOT,         &kp N7, &kp N8, &kp N9, &kp KP_MINUS, &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT),  &kp C_VOLUME_DOWN, \
-                                         &trans, &hpmt LSHFT N0, &trans, &trans, &trans, &trans \
+                &kp KP_DIVIDE,          &kp N1,       &kp N2,        &kp N3,         &kp KP_EQUAL, &kp ESCAPE, &kp BSPC,     &kp UP,     &kp UNDERSCORE, &kp C_PLAY_PAUSE, \
+                &hml LSHFT KP_MULTIPLY, &hml LALT N4, &hml LCTRL N5, &hml LGUI N6,   &kp KP_PLUS,  &kp PG_UP,  &kp LEFT,     &kp DOWN,   &kp RIGHT,      &hmr LSHFT C_VOLUME_UP, \
+                &hml RSHFT DOT,         &hml RALT N7, &hml RCTRL N8, &hml RGUI N9,   &kp KP_MINUS, &kp PG_DN,  &kp LA(LEFT), &kp RETURN, &kp LA(RIGHT),  &hmr RSHFT C_VOLUME_DOWN, \
+                                                      &trans,        &hpmt LSHFT N0, &trans,       &trans,     &trans,       &trans \
             )>;
         };
 

--- a/keymap-drawer/acid.svg
+++ b/keymap-drawer/acid.svg
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(504, 38)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(560, 28)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -173,18 +172,22 @@ text.right {
 <g transform="translate(28, 118)" class="key high keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">sS</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(84, 100)" class="key high keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">nN</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(140, 84)" class="key high keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">tT</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(196, 94)" class="key high keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">hH</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(252, 100)" class="key low keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -197,34 +200,42 @@ text.right {
 <g transform="translate(504, 94)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">aA</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(560, 84)" class="key high keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">eE</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(616, 100)" class="key high keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">iI</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(672, 118)" class="key medium keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">cC</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(28, 174)" class="key medium-low keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
+<text x="0" y="24" class="key medium-low hold">⇧</text>
 </g>
 <g transform="translate(84, 156)" class="key medium keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">fF</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(140, 140)" class="key medium-high keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">dD</text>
+<text x="0" y="24" class="key medium-high hold">⌃</text>
 </g>
 <g transform="translate(196, 150)" class="key medium-high keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(252, 156)" class="key low keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -237,22 +248,27 @@ text.right {
 <g transform="translate(504, 150)" class="key medium-high keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">uU</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(560, 140)" class="key high keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">oO</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(616, 156)" class="key medium keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">yY</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(672, 174)" class="key medium keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">wW</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(252, 224) rotate(25.0)" class="key high keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(298, 258) rotate(25.0)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -265,7 +281,7 @@ text.right {
 </g>
 <g transform="translate(448, 224) rotate(-25.0)" class="key high keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g class="combo combopos-0">
@@ -312,133 +328,101 @@ text.right {
 <rect rx="6" ry="6" x="518" y="176" width="28" height="15" class="combo"/>
 <text x="532" y="184" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="42" y="96" width="28" height="26" class="combo"/>
-<text x="56" y="109" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="630" y="96" width="28" height="26" class="combo"/>
-<text x="644" y="109" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
-<text x="112" y="92" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="574" y="79" width="28" height="26" class="combo"/>
-<text x="588" y="92" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-10">
-<rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
-<text x="168" y="89" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-11">
-<rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
-<text x="532" y="89" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-12">
-<rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
-<text x="168" y="145" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-13">
-<rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
-<text x="532" y="145" class="combo tap">⇧</text>
-</g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-6">
 <rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo low"/>
-<text x="168" y="33" class="combo low tap">qQ</text>
+<text x="168" y="33" class="combo low tap">vQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-7">
 <rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo low"/>
 <text x="588" y="36" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-8">
 <rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo low"/>
 <text x="112" y="36" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-9">
 <rect rx="6" ry="6" x="98" y="135" width="28" height="26" class="combo low"/>
 <text x="112" y="148" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <path d="M350,224 l-79,0" class="combo"/>
 <path d="M350,224 l79,0" class="combo"/>
 <rect rx="6" ry="6" x="336" y="211" width="28" height="26" class="combo"/>
 <text x="350" y="224" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
 <text x="28" y="90" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
 <text x="84" y="72" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
 <text x="140" y="56" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
 <text x="196" y="66" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="238" y="59" width="28" height="26" class="combo"/>
 <text x="252" y="72" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <path d="M281,128 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M281,128 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
 <rect rx="6" ry="6" x="267" y="115" width="28" height="26" class="combo"/>
 <text x="281" y="128" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <path d="M419,128 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M419,128 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
 <rect rx="6" ry="6" x="405" y="115" width="28" height="26" class="combo"/>
 <text x="419" y="128" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="434" y="59" width="28" height="26" class="combo"/>
 <text x="448" y="72" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
 <text x="504" y="66" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
 <text x="560" y="56" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
 <text x="616" y="72" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
 <text x="672" y="90" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
 <text x="224" y="41" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
 <text x="476" y="41" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
 <text x="224" y="97" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
 <text x="476" y="97" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
 <text x="224" y="153" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
 <text x="476" y="153" class="combo tap">]}</text>
 </g>
@@ -690,18 +674,22 @@ text.right {
 <g transform="translate(28, 118)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">*</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(84, 100)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">4</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(140, 84)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">5</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(196, 94)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">6</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(252, 100)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -726,24 +714,29 @@ text.right {
 <g transform="translate(672, 118)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(28, 174)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(84, 156)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">7</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(140, 140)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">8</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(196, 150)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(252, 156)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -768,8 +761,9 @@ text.right {
 <g transform="translate(672, 174)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(252, 224) rotate(25.0)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -802,135 +796,103 @@ text.right {
 <text x="532" y="184" class="combo tap">⏎</text>
 </g>
 <g class="combo combopos-2">
-<rect rx="6" ry="6" x="42" y="96" width="28" height="26" class="combo"/>
-<text x="56" y="109" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-3">
-<rect rx="6" ry="6" x="630" y="96" width="28" height="26" class="combo"/>
-<text x="644" y="109" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
-<text x="112" y="92" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-5">
-<rect rx="6" ry="6" x="574" y="79" width="28" height="26" class="combo"/>
-<text x="588" y="92" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
-<text x="168" y="89" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
-<text x="532" y="89" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
-<text x="168" y="145" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
-<text x="532" y="145" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
 <text x="28" y="90" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
 <text x="84" y="72" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
 <text x="140" y="56" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
 <text x="196" y="66" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="238" y="59" width="28" height="26" class="combo"/>
 <text x="252" y="72" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-7">
 <path d="M281,128 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M281,128 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
 <rect rx="6" ry="6" x="267" y="115" width="28" height="26" class="combo"/>
 <text x="281" y="128" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-8">
 <path d="M419,128 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M419,128 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
 <rect rx="6" ry="6" x="405" y="115" width="28" height="26" class="combo"/>
 <text x="419" y="128" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="434" y="59" width="28" height="26" class="combo"/>
 <text x="448" y="72" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
 <text x="504" y="66" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
 <text x="560" y="56" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
 <text x="616" y="72" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
 <text x="672" y="90" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
 <text x="224" y="41" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
 <text x="476" y="41" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
 <text x="224" y="97" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
 <text x="476" y="97" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
 <text x="224" y="153" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
 <text x="476" y="153" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="42" y="40" width="28" height="26" class="combo"/>
 <text x="56" y="53" class="combo tap">BT</text>
 <text x="56" y="64" class="combo hold">0</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo"/>
 <text x="112" y="36" class="combo tap">BT</text>
 <text x="112" y="47" class="combo hold">1</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo"/>
 <text x="168" y="33" class="combo tap">BT</text>
 <text x="168" y="44" class="combo hold">2</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="518" y="20" width="28" height="26" class="combo"/>
 <text x="532" y="33" class="combo tap">
 <tspan x="532" dy="-0.6em">BT</tspan><tspan x="532" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo"/>
 <text x="588" y="36" class="combo tap">
 <tspan x="588" dy="-0.6em">BT</tspan><tspan x="588" dy="1.2em">…</tspan>

--- a/keymap-drawer/acid.yaml
+++ b/keymap-drawer/acid.yaml
@@ -7,34 +7,34 @@ layers:
   - {t: mM, type: medium}
   - {t: xX, type: low}
   - {t: '/?', type: low}
-  - {t: ⌫, h: Sft+⌫}
+  - ⌫
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
-  - {t: sS, type: high}
-  - {t: nN, type: high}
-  - {t: tT, type: high}
-  - {t: hH, type: high}
+  - {t: sS, h: ⇧, type: high}
+  - {t: nN, h: ⎇, type: high}
+  - {t: tT, h: ⌃, type: high}
+  - {t: hH, h: ⌘, type: high}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - {t: aA, type: high}
-  - {t: eE, type: high}
-  - {t: iI, type: high}
-  - {t: cC, type: medium}
-  - {t: bB, type: medium-low}
-  - {t: fF, type: medium}
-  - {t: dD, type: medium-high}
-  - {t: lL, type: medium-high}
+  - {t: aA, h: ⌘, type: high}
+  - {t: eE, h: ⌃, type: high}
+  - {t: iI, h: ⎇, type: high}
+  - {t: cC, h: ⇧, type: medium}
+  - {t: bB, h: ⇧, type: medium-low}
+  - {t: fF, h: ⎇, type: medium}
+  - {t: dD, h: ⌃, type: medium-high}
+  - {t: lL, h: ⌘, type: medium-high}
   - {t: jJ, type: low}
   - {t: ',;', type: medium-low}
-  - {t: uU, type: medium-high}
-  - {t: oO, type: high}
-  - {t: yY, type: medium}
-  - {t: wW, type: medium}
-  - {t: rR, type: high}
+  - {t: uU, h: ⌘, type: medium-high}
+  - {t: oO, h: ⌃, type: high}
+  - {t: yY, h: ⎇, type: medium}
+  - {t: wW, h: ⇧, type: medium}
+  - {t: rR, h: ⇧, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵, h: Num+Nav, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
   Naginata:
   - {t: ⎋, h: Small-kana}
   - {left: き, right: め}
@@ -81,30 +81,30 @@ layers:
   - ↑
   - _
   - ⏯
-  - '*'
-  - '4'
-  - '5'
-  - '6'
+  - {t: '*', h: ⇧}
+  - {t: '4', h: ⎇}
+  - {t: '5', h: ⌃}
+  - {t: '6', h: ⌘}
   - +
   - ⇞
   - ←
   - ↓
   - →
-  - 'VOL
+  - {t: 'VOL
 
-    UP'
-  - .
-  - '7'
-  - '8'
-  - '9'
+      UP', h: ⇧}
+  - {t: ., h: ⇧}
+  - {t: '7', h: ⎇}
+  - {t: '8', h: ⌃}
+  - {t: '9', h: ⌘}
   - '-'
   - ⇟
   - ↞
   - ⏎
   - ↠
-  - 'VOL
+  - {t: 'VOL
 
-    DOWN'
+      DOWN', h: ⇧}
   - {t: '0', h: ⇧}
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}
@@ -146,32 +146,8 @@ combos:
   o: -0.02
   s: 0.5
   h: 15.0
-- p: [11, 10]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [12, 11]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [13, 12]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [16, 17]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [23, 22]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
-- p: [26, 27]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: qQ, type: low}
+  k: {t: vQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}

--- a/keymap-drawer/bivouac34.svg
+++ b/keymap-drawer/bivouac34.svg
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(407, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(459, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -173,18 +172,22 @@ text.right {
 <g transform="translate(28, 128)" class="key high keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">sS</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">nN</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">tT</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">hH</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(258, 182) rotate(22.0)" class="key low keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -197,54 +200,67 @@ text.right {
 <g transform="translate(426, 134) rotate(-22.0)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">aA</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(475, 88) rotate(-18.0)" class="key high keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">eE</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(544, 93) rotate(-10.0)" class="key high keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">iI</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(613, 128)" class="key medium keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">cC</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(28, 184)" class="key medium-low keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
+<text x="0" y="24" class="key medium-low hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">fF</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">dD</text>
+<text x="0" y="24" class="key medium-high hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(446, 186) rotate(-22.0)" class="key medium-high keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">uU</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(492, 142) rotate(-18.0)" class="key high keypos-25">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">oO</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(553, 148) rotate(-10.0)" class="key medium keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">yY</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(613, 184)" class="key medium keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">wW</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(200, 267) rotate(33.0)" class="key high keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(247, 299) rotate(33.0)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -257,7 +273,7 @@ text.right {
 </g>
 <g transform="translate(441, 267) rotate(-33.0)" class="key high keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g class="combo combopos-0">
@@ -304,133 +320,101 @@ text.right {
 <rect rx="6" ry="6" x="512" y="207" width="28" height="15" class="combo"/>
 <text x="526" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
-<text x="63" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="565" y="97" width="28" height="26" class="combo"/>
-<text x="579" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="496" y="78" width="28" height="26" class="combo"/>
-<text x="510" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-10">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-11">
-<rect rx="6" ry="6" x="437" y="98" width="28" height="26" class="combo"/>
-<text x="451" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-12">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-13">
-<rect rx="6" ry="6" x="455" y="151" width="28" height="26" class="combo"/>
-<text x="469" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-6">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">qQ</text>
+<text x="209" y="59" class="combo low tap">vQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-7">
 <rect rx="6" ry="6" x="483" y="24" width="28" height="26" class="combo low"/>
 <text x="497" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-8">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-9">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <path d="M321,267 l-102,0" class="combo"/>
 <path d="M321,267 l102,0" class="combo"/>
 <rect rx="6" ry="6" x="307" y="254" width="28" height="26" class="combo"/>
 <text x="321" y="267" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <path d="M335,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="321" y="143" width="28" height="26" class="combo"/>
 <text x="335" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="371" y="93" width="28" height="26" class="combo"/>
 <text x="385" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="402" y="95" width="28" height="26" class="combo"/>
 <text x="416" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="453" y="49" width="28" height="26" class="combo"/>
 <text x="467" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="526" y="53" width="28" height="26" class="combo"/>
 <text x="540" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="590" y="79" width="28" height="26" class="combo"/>
 <text x="604" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="381" y="119" width="28" height="26" class="combo"/>
 <text x="395" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="391" y="145" width="28" height="26" class="combo"/>
 <text x="405" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="401" y="171" width="28" height="26" class="combo"/>
 <text x="415" y="184" class="combo tap">]}</text>
 </g>
@@ -674,18 +658,22 @@ text.right {
 <g transform="translate(28, 128)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">*</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">4</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">5</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">6</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(258, 182) rotate(22.0)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -710,24 +698,29 @@ text.right {
 <g transform="translate(613, 128)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(28, 184)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">7</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">8</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(446, 186) rotate(-22.0)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -744,8 +737,9 @@ text.right {
 <g transform="translate(613, 184)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(200, 267) rotate(33.0)" class="key keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -778,110 +772,78 @@ text.right {
 <text x="526" y="214" class="combo tap">⏎</text>
 </g>
 <g class="combo combopos-2">
-<rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
-<text x="63" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-3">
-<rect rx="6" ry="6" x="565" y="97" width="28" height="26" class="combo"/>
-<text x="579" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-5">
-<rect rx="6" ry="6" x="496" y="78" width="28" height="26" class="combo"/>
-<text x="510" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="437" y="98" width="28" height="26" class="combo"/>
-<text x="451" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="455" y="151" width="28" height="26" class="combo"/>
-<text x="469" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-10">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-7">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-8">
 <path d="M335,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="321" y="143" width="28" height="26" class="combo"/>
 <text x="335" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="371" y="93" width="28" height="26" class="combo"/>
 <text x="385" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="402" y="95" width="28" height="26" class="combo"/>
 <text x="416" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="453" y="49" width="28" height="26" class="combo"/>
 <text x="467" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="526" y="53" width="28" height="26" class="combo"/>
 <text x="540" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="590" y="79" width="28" height="26" class="combo"/>
 <text x="604" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="381" y="119" width="28" height="26" class="combo"/>
 <text x="395" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="391" y="145" width="28" height="26" class="combo"/>
 <text x="405" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="401" y="171" width="28" height="26" class="combo"/>
 <text x="415" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivouac34.yaml
+++ b/keymap-drawer/bivouac34.yaml
@@ -7,32 +7,32 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - {t: ⌫, h: Sft+⌫}
+  - ⌫
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
-  - {t: sS, type: high}
-  - {t: nN, type: high}
-  - {t: tT, type: high}
-  - {t: hH, type: high}
+  - {t: sS, h: ⇧, type: high}
+  - {t: nN, h: ⎇, type: high}
+  - {t: tT, h: ⌃, type: high}
+  - {t: hH, h: ⌘, type: high}
   - {t: jJ, type: low}
   - {t: ',;', type: medium-low}
-  - {t: aA, type: high}
-  - {t: eE, type: high}
-  - {t: iI, type: high}
-  - {t: cC, type: medium}
-  - {t: bB, type: medium-low}
-  - {t: fF, type: medium}
-  - {t: dD, type: medium-high}
-  - {t: lL, type: medium-high}
-  - {t: uU, type: medium-high}
-  - {t: oO, type: high}
-  - {t: yY, type: medium}
-  - {t: wW, type: medium}
-  - {t: rR, type: high}
+  - {t: aA, h: ⌘, type: high}
+  - {t: eE, h: ⌃, type: high}
+  - {t: iI, h: ⎇, type: high}
+  - {t: cC, h: ⇧, type: medium}
+  - {t: bB, h: ⇧, type: medium-low}
+  - {t: fF, h: ⎇, type: medium}
+  - {t: dD, h: ⌃, type: medium-high}
+  - {t: lL, h: ⌘, type: medium-high}
+  - {t: uU, h: ⌘, type: medium-high}
+  - {t: oO, h: ⌃, type: high}
+  - {t: yY, h: ⎇, type: medium}
+  - {t: wW, h: ⇧, type: medium}
+  - {t: rR, h: ⇧, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵, h: Num+Nav, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
   Naginata:
   - {t: ⎋, h: Small-kana}
   - {left: き, right: め}
@@ -77,28 +77,28 @@ layers:
   - ↑
   - _
   - ⏯
-  - '*'
-  - '4'
-  - '5'
-  - '6'
+  - {t: '*', h: ⇧}
+  - {t: '4', h: ⎇}
+  - {t: '5', h: ⌃}
+  - {t: '6', h: ⌘}
   - '-'
   - ⇟
   - ←
   - ↓
   - →
-  - 'VOL
+  - {t: 'VOL
 
-    UP'
-  - .
-  - '7'
-  - '8'
-  - '9'
+      UP', h: ⇧}
+  - {t: ., h: ⇧}
+  - {t: '7', h: ⎇}
+  - {t: '8', h: ⌃}
+  - {t: '9', h: ⌘}
   - ↞
   - ⏎
   - ↠
-  - 'VOL
+  - {t: 'VOL
 
-    DOWN'
+      DOWN', h: ⇧}
   - {t: '0', h: ⇧}
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}
@@ -140,32 +140,8 @@ combos:
   o: -0.02
   s: 0.5
   h: 15.0
-- p: [11, 10]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [12, 11]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [13, 12]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [16, 17]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [23, 22]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
-- p: [24, 25]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: qQ, type: low}
+  k: {t: vQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}

--- a/keymap-drawer/bivvy16d.svg
+++ b/keymap-drawer/bivvy16d.svg
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(463, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(515, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -173,18 +172,22 @@ text.right {
 <g transform="translate(28, 128)" class="key high keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">sS</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">nN</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">tT</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">hH</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(258, 182) rotate(22.0)" class="key low keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -197,59 +200,72 @@ text.right {
 <g transform="translate(482, 134) rotate(-22.0)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">aA</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(531, 88) rotate(-18.0)" class="key high keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">eE</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(600, 93) rotate(-10.0)" class="key high keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">iI</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(669, 128)" class="key medium keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">cC</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(28, 184)" class="key medium-low keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
+<text x="0" y="24" class="key medium-low hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">fF</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">dD</text>
+<text x="0" y="24" class="key medium-high hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(245, 278) rotate(37.0)" class="key high keypos-24">
 <rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(453, 275) rotate(-37.0)" class="key high keypos-25">
 <rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(502, 186) rotate(-22.0)" class="key medium-high keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">uU</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(548, 142) rotate(-18.0)" class="key high keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">oO</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(609, 148) rotate(-10.0)" class="key medium keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">yY</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(669, 184)" class="key medium keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">wW</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(95, 315)" class="key keypos-30">
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
@@ -337,133 +353,101 @@ text.right {
 <rect rx="6" ry="6" x="568" y="207" width="28" height="15" class="combo"/>
 <text x="582" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
-<text x="63" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="621" y="97" width="28" height="26" class="combo"/>
-<text x="635" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="552" y="78" width="28" height="26" class="combo"/>
-<text x="566" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-10">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-11">
-<rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
-<text x="507" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-12">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-13">
-<rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
-<text x="525" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-6">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">qQ</text>
+<text x="209" y="59" class="combo low tap">vQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-7">
 <rect rx="6" ry="6" x="539" y="24" width="28" height="26" class="combo low"/>
 <text x="553" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-8">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-9">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <path d="M349,276 l-72,1" class="combo"/>
 <path d="M349,276 l72,-1" class="combo"/>
 <rect rx="6" ry="6" x="335" y="263" width="28" height="26" class="combo"/>
 <text x="349" y="276" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
 <text x="391" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
 <text x="441" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
 <text x="472" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
 <text x="523" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
 <text x="596" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
 <text x="660" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
 <text x="451" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
 <text x="461" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
 <text x="471" y="184" class="combo tap">]}</text>
 </g>
@@ -740,18 +724,22 @@ text.right {
 <g transform="translate(28, 128)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">*</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">4</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">5</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">6</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(258, 182) rotate(22.0)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -776,24 +764,29 @@ text.right {
 <g transform="translate(669, 128)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(28, 184)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">7</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">8</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(245, 278) rotate(37.0)" class="key keypos-24">
 <rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key"/>
@@ -818,8 +811,9 @@ text.right {
 <g transform="translate(669, 184)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(95, 315)" class="key keypos-30">
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
@@ -878,110 +872,78 @@ text.right {
 <text x="582" y="214" class="combo tap">⏎</text>
 </g>
 <g class="combo combopos-2">
-<rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
-<text x="63" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-3">
-<rect rx="6" ry="6" x="621" y="97" width="28" height="26" class="combo"/>
-<text x="635" y="110" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-5">
-<rect rx="6" ry="6" x="552" y="78" width="28" height="26" class="combo"/>
-<text x="566" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
-<text x="507" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
-<text x="525" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-10">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-7">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-8">
 <path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
 <text x="391" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
 <text x="441" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
 <text x="472" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
 <text x="523" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
 <text x="596" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
 <text x="660" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
 <text x="451" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
 <text x="461" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
 <text x="471" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivvy16d.yaml
+++ b/keymap-drawer/bivvy16d.yaml
@@ -7,30 +7,30 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - {t: ⌫, h: Sft+⌫}
+  - ⌫
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
-  - {t: sS, type: high}
-  - {t: nN, type: high}
-  - {t: tT, type: high}
-  - {t: hH, type: high}
+  - {t: sS, h: ⇧, type: high}
+  - {t: nN, h: ⎇, type: high}
+  - {t: tT, h: ⌃, type: high}
+  - {t: hH, h: ⌘, type: high}
   - {t: jJ, type: low}
   - {t: ',;', type: medium-low}
-  - {t: aA, type: high}
-  - {t: eE, type: high}
-  - {t: iI, type: high}
-  - {t: cC, type: medium}
-  - {t: bB, type: medium-low}
-  - {t: fF, type: medium}
-  - {t: dD, type: medium-high}
-  - {t: lL, type: medium-high}
-  - {t: rR, type: high}
-  - {t: ⎵, h: Num+Nav, type: high}
-  - {t: uU, type: medium-high}
-  - {t: oO, type: high}
-  - {t: yY, type: medium}
-  - {t: wW, type: medium}
+  - {t: aA, h: ⌘, type: high}
+  - {t: eE, h: ⌃, type: high}
+  - {t: iI, h: ⎇, type: high}
+  - {t: cC, h: ⇧, type: medium}
+  - {t: bB, h: ⇧, type: medium-low}
+  - {t: fF, h: ⎇, type: medium}
+  - {t: dD, h: ⌃, type: medium-high}
+  - {t: lL, h: ⌘, type: medium-high}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: uU, h: ⌘, type: medium-high}
+  - {t: oO, h: ⌃, type: high}
+  - {t: yY, h: ⎇, type: medium}
+  - {t: wW, h: ⇧, type: medium}
   - ⇟
   - ↖
   - KP ENTER
@@ -93,30 +93,30 @@ layers:
   - ↑
   - _
   - ⏯
-  - '*'
-  - '4'
-  - '5'
-  - '6'
+  - {t: '*', h: ⇧}
+  - {t: '4', h: ⎇}
+  - {t: '5', h: ⌃}
+  - {t: '6', h: ⌘}
   - '-'
   - ⇟
   - ←
   - ↓
   - →
-  - 'VOL
+  - {t: 'VOL
 
-    UP'
-  - .
-  - '7'
-  - '8'
-  - '9'
+      UP', h: ⇧}
+  - {t: ., h: ⇧}
+  - {t: '7', h: ⎇}
+  - {t: '8', h: ⌃}
+  - {t: '9', h: ⌘}
   - {t: '0', h: ⇧}
   - {type: held}
   - ↞
   - ⏎
   - ↠
-  - 'VOL
+  - {t: 'VOL
 
-    DOWN'
+      DOWN', h: ⇧}
   - ⇟
   - ↖
   - KP ENTER
@@ -164,32 +164,8 @@ combos:
   o: -0.02
   s: 0.5
   h: 15.0
-- p: [11, 10]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [12, 11]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [13, 12]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [16, 17]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [23, 22]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
-- p: [26, 27]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: qQ, type: low}
+  k: {t: vQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}

--- a/keymap-drawer/goldilocks32.svg
+++ b/keymap-drawer/goldilocks32.svg
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(407, 85) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(459, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -173,18 +172,22 @@ text.right {
 <g transform="translate(28, 132)" class="key high keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">sS</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(97, 95) rotate(10.0)" class="key high keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">nN</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(166, 90) rotate(18.0)" class="key high keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">tT</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(214, 139) rotate(22.0)" class="key high keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">hH</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(257, 189) rotate(22.0)" class="key low keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -197,59 +200,72 @@ text.right {
 <g transform="translate(426, 139) rotate(-22.0)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">aA</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(474, 90) rotate(-18.0)" class="key high keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">eE</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(543, 95) rotate(-10.0)" class="key high keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">iI</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(612, 132)" class="key medium keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">cC</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(28, 190)" class="key medium-low keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
+<text x="0" y="24" class="key medium-low hold">⇧</text>
 </g>
 <g transform="translate(88, 152) rotate(10.0)" class="key medium keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">fF</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(150, 145) rotate(18.0)" class="key medium-high keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">dD</text>
+<text x="0" y="24" class="key medium-high hold">⌃</text>
 </g>
 <g transform="translate(195, 192) rotate(22.0)" class="key medium-high keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(251, 274) rotate(37.0)" class="key high keypos-24">
 <rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(389, 274) rotate(-37.0)" class="key high keypos-25">
 <rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(445, 192) rotate(-22.0)" class="key medium-high keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">uU</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(491, 145) rotate(-18.0)" class="key high keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">oO</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(552, 152) rotate(-10.0)" class="key medium keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">yY</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(612, 190)" class="key medium keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">wW</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(95, 207)" class="key keypos-30">
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
@@ -315,131 +331,99 @@ text.right {
 <rect rx="6" ry="6" x="511" y="213" width="28" height="15" class="combo"/>
 <text x="525" y="220" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="48" y="101" width="28" height="26" class="combo"/>
-<text x="62" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="564" y="101" width="28" height="26" class="combo"/>
-<text x="578" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
-<text x="131" y="93" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="495" y="80" width="28" height="26" class="combo"/>
-<text x="509" y="93" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-10">
-<rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
-<text x="190" y="115" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-11">
-<rect rx="6" ry="6" x="436" y="102" width="28" height="26" class="combo"/>
-<text x="450" y="115" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-12">
-<rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
-<text x="172" y="169" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-13">
-<rect rx="6" ry="6" x="454" y="156" width="28" height="26" class="combo"/>
-<text x="468" y="169" class="combo tap">⇧</text>
-</g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-6">
 <rect rx="6" ry="6" x="193" y="47" width="28" height="26" class="combo low"/>
-<text x="207" y="60" class="combo low tap">qQ</text>
+<text x="207" y="60" class="combo low tap">vQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-7">
 <rect rx="6" ry="6" x="482" y="24" width="28" height="26" class="combo low"/>
 <text x="496" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-8">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-9">
 <rect rx="6" ry="6" x="105" y="136" width="28" height="26" class="combo low"/>
 <text x="119" y="149" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="306" y="261" width="28" height="26" class="combo"/>
 <text x="320" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
 <text x="37" y="98" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
 <text x="101" y="67" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
 <text x="174" y="63" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
 <text x="224" y="112" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
 <text x="255" y="110" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
 <rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
 <text x="305" y="162" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <path d="M335,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
 <rect rx="6" ry="6" x="321" y="149" width="28" height="26" class="combo"/>
 <text x="335" y="162" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="371" y="97" width="28" height="26" class="combo"/>
 <text x="385" y="110" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="402" y="99" width="28" height="26" class="combo"/>
 <text x="416" y="112" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="452" y="50" width="28" height="26" class="combo"/>
 <text x="466" y="63" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="525" y="54" width="28" height="26" class="combo"/>
 <text x="539" y="67" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="589" y="85" width="28" height="26" class="combo"/>
 <text x="603" y="98" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
 <text x="245" y="137" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="381" y="124" width="28" height="26" class="combo"/>
 <text x="395" y="137" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
 <text x="236" y="164" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="390" y="151" width="28" height="26" class="combo"/>
 <text x="404" y="164" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
 <text x="226" y="191" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="400" y="178" width="28" height="26" class="combo"/>
 <text x="414" y="191" class="combo tap">]}</text>
 </g>
@@ -694,18 +678,22 @@ text.right {
 <g transform="translate(28, 132)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">*</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(97, 95) rotate(10.0)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">4</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(166, 90) rotate(18.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">5</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(214, 139) rotate(22.0)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">6</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(257, 189) rotate(22.0)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -730,24 +718,29 @@ text.right {
 <g transform="translate(612, 132)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(28, 190)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(88, 152) rotate(10.0)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">7</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(150, 145) rotate(18.0)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">8</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(195, 192) rotate(22.0)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(251, 274) rotate(37.0)" class="key keypos-24">
 <rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key"/>
@@ -772,8 +765,9 @@ text.right {
 <g transform="translate(612, 190)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(95, 207)" class="key keypos-30">
 <rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
@@ -810,110 +804,78 @@ text.right {
 <text x="525" y="220" class="combo tap">⏎</text>
 </g>
 <g class="combo combopos-2">
-<rect rx="6" ry="6" x="48" y="101" width="28" height="26" class="combo"/>
-<text x="62" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-3">
-<rect rx="6" ry="6" x="564" y="101" width="28" height="26" class="combo"/>
-<text x="578" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
-<text x="131" y="93" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-5">
-<rect rx="6" ry="6" x="495" y="80" width="28" height="26" class="combo"/>
-<text x="509" y="93" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
-<text x="190" y="115" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="436" y="102" width="28" height="26" class="combo"/>
-<text x="450" y="115" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
-<text x="172" y="169" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="454" y="156" width="28" height="26" class="combo"/>
-<text x="468" y="169" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-10">
 <rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
 <text x="37" y="98" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
 <text x="101" y="67" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
 <text x="174" y="63" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
 <text x="224" y="112" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
 <text x="255" y="110" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-7">
 <path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
 <rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
 <text x="305" y="162" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-8">
 <path d="M335,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M335,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
 <rect rx="6" ry="6" x="321" y="149" width="28" height="26" class="combo"/>
 <text x="335" y="162" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="371" y="97" width="28" height="26" class="combo"/>
 <text x="385" y="110" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="402" y="99" width="28" height="26" class="combo"/>
 <text x="416" y="112" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="452" y="50" width="28" height="26" class="combo"/>
 <text x="466" y="63" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="525" y="54" width="28" height="26" class="combo"/>
 <text x="539" y="67" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="589" y="85" width="28" height="26" class="combo"/>
 <text x="603" y="98" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
 <text x="245" y="137" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="381" y="124" width="28" height="26" class="combo"/>
 <text x="395" y="137" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
 <text x="236" y="164" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="390" y="151" width="28" height="26" class="combo"/>
 <text x="404" y="164" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
 <text x="226" y="191" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="400" y="178" width="28" height="26" class="combo"/>
 <text x="414" y="191" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/goldilocks32.yaml
+++ b/keymap-drawer/goldilocks32.yaml
@@ -7,30 +7,30 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - {t: ⌫, h: Sft+⌫}
+  - ⌫
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
-  - {t: sS, type: high}
-  - {t: nN, type: high}
-  - {t: tT, type: high}
-  - {t: hH, type: high}
+  - {t: sS, h: ⇧, type: high}
+  - {t: nN, h: ⎇, type: high}
+  - {t: tT, h: ⌃, type: high}
+  - {t: hH, h: ⌘, type: high}
   - {t: jJ, type: low}
   - {t: ',;', type: medium-low}
-  - {t: aA, type: high}
-  - {t: eE, type: high}
-  - {t: iI, type: high}
-  - {t: cC, type: medium}
-  - {t: bB, type: medium-low}
-  - {t: fF, type: medium}
-  - {t: dD, type: medium-high}
-  - {t: lL, type: medium-high}
-  - {t: rR, type: high}
-  - {t: ⎵, h: Num+Nav, type: high}
-  - {t: uU, type: medium-high}
-  - {t: oO, type: high}
-  - {t: yY, type: medium}
-  - {t: wW, type: medium}
+  - {t: aA, h: ⌘, type: high}
+  - {t: eE, h: ⌃, type: high}
+  - {t: iI, h: ⎇, type: high}
+  - {t: cC, h: ⇧, type: medium}
+  - {t: bB, h: ⇧, type: medium-low}
+  - {t: fF, h: ⎇, type: medium}
+  - {t: dD, h: ⌃, type: medium-high}
+  - {t: lL, h: ⌘, type: medium-high}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: uU, h: ⌘, type: medium-high}
+  - {t: oO, h: ⌃, type: high}
+  - {t: yY, h: ⎇, type: medium}
+  - {t: wW, h: ⇧, type: medium}
   - ↑
   - ←
   - ⏎
@@ -83,30 +83,30 @@ layers:
   - ↑
   - _
   - ⏯
-  - '*'
-  - '4'
-  - '5'
-  - '6'
+  - {t: '*', h: ⇧}
+  - {t: '4', h: ⎇}
+  - {t: '5', h: ⌃}
+  - {t: '6', h: ⌘}
   - '-'
   - ⇟
   - ←
   - ↓
   - →
-  - 'VOL
+  - {t: 'VOL
 
-    UP'
-  - .
-  - '7'
-  - '8'
-  - '9'
+      UP', h: ⇧}
+  - {t: ., h: ⇧}
+  - {t: '7', h: ⎇}
+  - {t: '8', h: ⌃}
+  - {t: '9', h: ⌘}
   - {t: '0', h: ⇧}
   - {type: held}
   - ↞
   - ⏎
   - ↠
-  - 'VOL
+  - {t: 'VOL
 
-    DOWN'
+      DOWN', h: ⇧}
   - ↑
   - ←
   - ⏎
@@ -149,32 +149,8 @@ combos:
   o: -0.02
   s: 0.5
   h: 15.0
-- p: [11, 10]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [12, 11]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [13, 12]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [16, 17]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [23, 22]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
-- p: [26, 27]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: qQ, type: low}
+  k: {t: vQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}

--- a/keymap-drawer/hesse.svg
+++ b/keymap-drawer/hesse.svg
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -173,18 +172,22 @@ text.right {
 <g transform="translate(28, 119)" class="key high keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">sS</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">nN</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">tT</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">hH</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(262, 169) rotate(22.0)" class="key low keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -197,34 +200,42 @@ text.right {
 <g transform="translate(505, 134) rotate(-22.0)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">aA</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(554, 88) rotate(-18.0)" class="key high keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">eE</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(622, 93) rotate(-10.0)" class="key high keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">iI</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(692, 119)" class="key medium keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">cC</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(28, 175)" class="key medium-low keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
+<text x="0" y="24" class="key medium-low hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">fF</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">dD</text>
+<text x="0" y="24" class="key medium-high hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(242, 221) rotate(22.0)" class="key low keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -237,18 +248,22 @@ text.right {
 <g transform="translate(524, 186) rotate(-22.0)" class="key medium-high keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">uU</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(570, 142) rotate(-18.0)" class="key high keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">oO</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(632, 148) rotate(-10.0)" class="key medium keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">yY</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(692, 175)" class="key medium keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">wW</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(143, 241) rotate(22.0)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -257,6 +272,7 @@ text.right {
 <g transform="translate(199, 274) rotate(37.0)" class="key high keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -269,7 +285,7 @@ text.right {
 </g>
 <g transform="translate(521, 274) rotate(-37.0)" class="key high keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(576, 241) rotate(-22.0)" class="key keypos-35">
@@ -323,133 +339,101 @@ text.right {
 <rect rx="6" ry="6" x="591" y="207" width="28" height="15" class="combo"/>
 <text x="605" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
-<text x="63" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
-<text x="657" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
-<text x="588" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-10">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-11">
-<rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
-<text x="529" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-12">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-13">
-<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
-<text x="547" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-6">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">qQ</text>
+<text x="209" y="59" class="combo low tap">vQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-7">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
 <text x="575" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-8">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-9">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <path d="M360,274 l-142,0" class="combo"/>
 <path d="M360,274 l142,0" class="combo"/>
 <rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
 <text x="360" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
@@ -712,18 +696,22 @@ text.right {
 <g transform="translate(28, 119)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">*</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">4</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">5</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">6</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(262, 169) rotate(22.0)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -748,24 +736,29 @@ text.right {
 <g transform="translate(692, 119)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(28, 175)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">7</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">8</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(242, 221) rotate(22.0)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -790,8 +783,9 @@ text.right {
 <g transform="translate(692, 175)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(143, 241) rotate(22.0)" class="key trans keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -832,135 +826,103 @@ text.right {
 <text x="605" y="214" class="combo tap">⏎</text>
 </g>
 <g class="combo combopos-2">
-<rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
-<text x="63" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-3">
-<rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
-<text x="657" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-5">
-<rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
-<text x="588" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
-<text x="529" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
-<text x="547" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-7">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-8">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="53" y="37" width="28" height="26" class="combo"/>
 <text x="67" y="50" class="combo tap">BT</text>
 <text x="67" y="61" class="combo hold">0</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo"/>
 <text x="144" y="37" class="combo tap">BT</text>
 <text x="144" y="48" class="combo hold">1</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo"/>
 <text x="209" y="59" class="combo tap">BT</text>
 <text x="209" y="70" class="combo hold">2</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="497" y="46" width="28" height="26" class="combo"/>
 <text x="511" y="59" class="combo tap">
 <tspan x="511" dy="-0.6em">BT</tspan><tspan x="511" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo"/>
 <text x="575" y="37" class="combo tap">
 <tspan x="575" dy="-0.6em">BT</tspan><tspan x="575" dy="1.2em">…</tspan>

--- a/keymap-drawer/hesse.yaml
+++ b/keymap-drawer/hesse.yaml
@@ -7,35 +7,35 @@ layers:
   - {t: mM, type: medium}
   - {t: xX, type: low}
   - {t: '/?', type: low}
-  - {t: ⌫, h: Sft+⌫}
+  - ⌫
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
-  - {t: sS, type: high}
-  - {t: nN, type: high}
-  - {t: tT, type: high}
-  - {t: hH, type: high}
+  - {t: sS, h: ⇧, type: high}
+  - {t: nN, h: ⎇, type: high}
+  - {t: tT, h: ⌃, type: high}
+  - {t: hH, h: ⌘, type: high}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - {t: aA, type: high}
-  - {t: eE, type: high}
-  - {t: iI, type: high}
-  - {t: cC, type: medium}
-  - {t: bB, type: medium-low}
-  - {t: fF, type: medium}
-  - {t: dD, type: medium-high}
-  - {t: lL, type: medium-high}
+  - {t: aA, h: ⌘, type: high}
+  - {t: eE, h: ⌃, type: high}
+  - {t: iI, h: ⎇, type: high}
+  - {t: cC, h: ⇧, type: medium}
+  - {t: bB, h: ⇧, type: medium-low}
+  - {t: fF, h: ⎇, type: medium}
+  - {t: dD, h: ⌃, type: medium-high}
+  - {t: lL, h: ⌘, type: medium-high}
   - {t: jJ, type: low}
   - {t: ',;', type: medium-low}
-  - {t: uU, type: medium-high}
-  - {t: oO, type: high}
-  - {t: yY, type: medium}
-  - {t: wW, type: medium}
+  - {t: uU, h: ⌘, type: medium-high}
+  - {t: oO, h: ⌃, type: high}
+  - {t: yY, h: ⎇, type: medium}
+  - {t: wW, h: ⇧, type: medium}
   - ↹
-  - {t: rR, type: high}
+  - {t: rR, h: ⇧, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵, h: Num+Nav, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
   - Num + Nav
   Naginata:
   - {t: ⎋, h: Small-kana}
@@ -85,30 +85,30 @@ layers:
   - ↑
   - _
   - ⏯
-  - '*'
-  - '4'
-  - '5'
-  - '6'
+  - {t: '*', h: ⇧}
+  - {t: '4', h: ⎇}
+  - {t: '5', h: ⌃}
+  - {t: '6', h: ⌘}
   - +
   - ⇞
   - ←
   - ↓
   - →
-  - 'VOL
+  - {t: 'VOL
 
-    UP'
-  - .
-  - '7'
-  - '8'
-  - '9'
+      UP', h: ⇧}
+  - {t: ., h: ⇧}
+  - {t: '7', h: ⎇}
+  - {t: '8', h: ⌃}
+  - {t: '9', h: ⌘}
   - '-'
   - ⇟
   - ↞
   - ⏎
   - ↠
-  - 'VOL
+  - {t: 'VOL
 
-    DOWN'
+      DOWN', h: ⇧}
   - {t: ▽, type: trans}
   - {t: '0', h: ⇧}
   - {t: ▽, type: trans}
@@ -152,32 +152,8 @@ combos:
   o: -0.02
   s: 0.5
   h: 15.0
-- p: [11, 10]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [12, 11]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [13, 12]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [16, 17]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [23, 22]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
-- p: [26, 27]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: qQ, type: low}
+  k: {t: vQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}

--- a/keymap-drawer/slump52.svg
+++ b/keymap-drawer/slump52.svg
@@ -160,7 +160,6 @@ text.right {
 <g transform="translate(437, 77) rotate(-25.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(491, 54) rotate(-21.0)" class="key medium-low keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -197,14 +196,17 @@ text.right {
 <g transform="translate(102, 88) rotate(7.0)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">nN</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(177, 105) rotate(19.0)" class="key high keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">tT</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(232, 128) rotate(25.0)" class="key high keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">hH</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(272, 177) rotate(25.0)" class="key low keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -217,14 +219,17 @@ text.right {
 <g transform="translate(461, 128) rotate(-25.0)" class="key high keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">aA</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(517, 105) rotate(-19.0)" class="key high keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">eE</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(591, 88) rotate(-7.0)" class="key high keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">iI</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(666, 84)" class="key low keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -245,43 +250,52 @@ text.right {
 <g transform="translate(28, 140)" class="key high keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">sS</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(89, 144) rotate(7.0)" class="key medium keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">fF</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(151, 157) rotate(16.0)" class="key medium-high keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">dD</text>
+<text x="0" y="24" class="key medium-high hold">⌃</text>
 </g>
 <g transform="translate(209, 179) rotate(25.0)" class="key medium-high keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(248, 228) rotate(25.0)" class="key high keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(446, 228) rotate(-25.0)" class="key high keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(485, 179) rotate(-25.0)" class="key medium-high keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">uU</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(543, 157) rotate(-16.0)" class="key high keypos-35">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">oO</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(604, 144) rotate(-7.0)" class="key medium keypos-36">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">yY</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(666, 140)" class="key medium keypos-37">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">cC</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(722, 140)" class="key keypos-38">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -298,10 +312,12 @@ text.right {
 <g transform="translate(28, 196)" class="key medium-low keypos-41">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
+<text x="0" y="24" class="key medium-low hold">⇧</text>
 </g>
 <g transform="translate(300, 258) rotate(35.0)" class="key high keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(347, 297) rotate(-45.0)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -310,7 +326,7 @@ text.right {
 </g>
 <g transform="translate(393, 258) rotate(-35.0)" class="key high keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(547, 301) rotate(-11.5)" class="key keypos-45">
@@ -332,6 +348,7 @@ text.right {
 <g transform="translate(666, 196)" class="key medium keypos-49">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">wW</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(722, 196)" class="key keypos-50">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -385,131 +402,99 @@ text.right {
 <rect rx="6" ry="6" x="501" y="199" width="28" height="15" class="combo"/>
 <text x="515" y="207" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="51" y="101" width="28" height="26" class="combo"/>
-<text x="65" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="614" y="101" width="28" height="26" class="combo"/>
-<text x="628" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
-<text x="140" y="97" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="540" y="84" width="28" height="26" class="combo"/>
-<text x="554" y="97" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-10">
-<rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
-<text x="205" y="116" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-11">
-<rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
-<text x="489" y="116" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-12">
-<rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
-<text x="180" y="168" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-13">
-<rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
-<text x="514" y="168" class="combo tap">⇧</text>
-</g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-6">
 <rect rx="6" ry="6" x="216" y="53" width="28" height="26" class="combo low"/>
-<text x="230" y="66" class="combo low tap">qQ</text>
+<text x="230" y="66" class="combo low tap">vQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-7">
 <rect rx="6" ry="6" x="505" y="33" width="28" height="26" class="combo low"/>
 <text x="519" y="46" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-8">
 <rect rx="6" ry="6" x="160" y="33" width="28" height="26" class="combo low"/>
 <text x="174" y="46" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-9">
 <rect rx="6" ry="6" x="106" y="137" width="28" height="26" class="combo low"/>
 <text x="120" y="150" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="333" y="245" width="28" height="26" class="combo"/>
 <text x="347" y="258" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
 <text x="28" y="112" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
 <text x="124" y="63" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
 <text x="190" y="80" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
 <text x="244" y="102" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
 <text x="276" y="102" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
 <rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
 <text x="324" y="151" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
 <rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
 <text x="370" y="151" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
 <text x="418" y="102" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
 <text x="449" y="102" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
 <text x="504" y="80" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
 <text x="570" y="63" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
 <text x="666" y="112" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
 <text x="264" y="127" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
 <text x="430" y="127" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
 <text x="252" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
 <text x="442" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
 <text x="240" y="178" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
 <text x="454" y="178" class="combo tap">]}</text>
 </g>
@@ -863,14 +848,17 @@ text.right {
 <g transform="translate(102, 88) rotate(7.0)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">4</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(177, 105) rotate(19.0)" class="key keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">5</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(232, 128) rotate(25.0)" class="key keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">6</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(272, 177) rotate(25.0)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -911,18 +899,22 @@ text.right {
 <g transform="translate(28, 140)" class="key keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">*</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(89, 144) rotate(7.0)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">7</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(151, 157) rotate(16.0)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">8</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(209, 179) rotate(25.0)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(248, 228) rotate(25.0)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -947,8 +939,9 @@ text.right {
 <g transform="translate(666, 140)" class="key keypos-37">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(722, 140)" class="key keypos-38">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -965,6 +958,7 @@ text.right {
 <g transform="translate(28, 196)" class="key keypos-41">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(300, 258) rotate(35.0)" class="key keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -998,8 +992,9 @@ text.right {
 <g transform="translate(666, 196)" class="key keypos-49">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(722, 196)" class="key keypos-50">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1024,110 +1019,78 @@ text.right {
 <text x="515" y="207" class="combo tap">⏎</text>
 </g>
 <g class="combo combopos-2">
-<rect rx="6" ry="6" x="51" y="101" width="28" height="26" class="combo"/>
-<text x="65" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-3">
-<rect rx="6" ry="6" x="614" y="101" width="28" height="26" class="combo"/>
-<text x="628" y="114" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
-<text x="140" y="97" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-5">
-<rect rx="6" ry="6" x="540" y="84" width="28" height="26" class="combo"/>
-<text x="554" y="97" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
-<text x="205" y="116" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
-<text x="489" y="116" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
-<text x="180" y="168" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
-<text x="514" y="168" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
 <text x="28" y="112" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
 <text x="124" y="63" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
 <text x="190" y="80" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
 <text x="244" y="102" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
 <text x="276" y="102" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-7">
 <path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
 <rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
 <text x="324" y="151" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-8">
 <path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
 <rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
 <text x="370" y="151" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
 <text x="418" y="102" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
 <text x="449" y="102" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
 <text x="504" y="80" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
 <text x="570" y="63" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
 <text x="666" y="112" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
 <text x="264" y="127" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
 <text x="430" y="127" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
 <text x="252" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
 <text x="442" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
 <text x="240" y="178" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
 <text x="454" y="178" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/slump52.yaml
+++ b/keymap-drawer/slump52.yaml
@@ -8,7 +8,7 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - {t: ⌫, h: Sft+⌫}
+  - ⌫
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
@@ -17,40 +17,40 @@ layers:
   - '8'
   - '9'
   - ⎋
-  - {t: nN, type: high}
-  - {t: tT, type: high}
-  - {t: hH, type: high}
+  - {t: nN, h: ⎇, type: high}
+  - {t: tT, h: ⌃, type: high}
+  - {t: hH, h: ⌘, type: high}
   - {t: jJ, type: low}
   - {t: ',;', type: medium-low}
-  - {t: aA, type: high}
-  - {t: eE, type: high}
-  - {t: iI, type: high}
+  - {t: aA, h: ⌘, type: high}
+  - {t: eE, h: ⌃, type: high}
+  - {t: iI, h: ⎇, type: high}
   - {t: '/?', type: low}
   - '4'
   - '5'
   - '6'
-  - {t: sS, type: high}
-  - {t: fF, type: medium}
-  - {t: dD, type: medium-high}
-  - {t: lL, type: medium-high}
-  - {t: rR, type: high}
-  - {t: ⎵, h: Num+Nav, type: high}
-  - {t: uU, type: medium-high}
-  - {t: oO, type: high}
-  - {t: yY, type: medium}
-  - {t: cC, type: medium}
+  - {t: sS, h: ⇧, type: high}
+  - {t: fF, h: ⎇, type: medium}
+  - {t: dD, h: ⌃, type: medium-high}
+  - {t: lL, h: ⌘, type: medium-high}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: uU, h: ⌘, type: medium-high}
+  - {t: oO, h: ⌃, type: high}
+  - {t: yY, h: ⎇, type: medium}
+  - {t: cC, h: ⇧, type: medium}
   - '1'
   - '2'
   - '3'
-  - {t: bB, type: medium-low}
-  - {t: rR, type: high}
+  - {t: bB, h: ⇧, type: medium-low}
+  - {t: rR, h: ⇧, type: high}
   - {t: ⌫, h: ⇧}
-  - {t: ⎵, h: Num+Nav, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
   - ←
   - ↓
   - ↑
   - →
-  - {t: wW, type: medium}
+  - {t: wW, h: ⇧, type: medium}
   - '0'
   - RET
   Naginata:
@@ -123,9 +123,9 @@ layers:
   - '8'
   - '9'
   - /
-  - '4'
-  - '5'
-  - '6'
+  - {t: '4', h: ⎇}
+  - {t: '5', h: ⌃}
+  - {t: '6', h: ⌘}
   - '-'
   - ⇟
   - ←
@@ -135,22 +135,22 @@ layers:
   - '4'
   - '5'
   - '6'
-  - '*'
-  - '7'
-  - '8'
-  - '9'
+  - {t: '*', h: ⇧}
+  - {t: '7', h: ⎇}
+  - {t: '8', h: ⌃}
+  - {t: '9', h: ⌘}
   - {t: '0', h: ⇧}
   - {type: held}
   - ↞
   - ⏎
   - ↠
-  - 'VOL
+  - {t: 'VOL
 
-    UP'
+      UP', h: ⇧}
   - '1'
   - '2'
   - '3'
-  - .
+  - {t: ., h: ⇧}
   - {t: '0', h: ⇧}
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}
@@ -158,9 +158,9 @@ layers:
   - ↓
   - ↑
   - →
-  - 'VOL
+  - {t: 'VOL
 
-    DOWN'
+      DOWN', h: ⇧}
   - '0'
   - RET
 combos:
@@ -200,32 +200,8 @@ combos:
   o: -0.02
   s: 0.5
   h: 15.0
-- p: [16, 28]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [23, 37]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [17, 16]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [22, 23]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [18, 17]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [21, 22]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [31, 30]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
-- p: [34, 35]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
 - p: [4, 3]
-  k: {t: qQ, type: low}
+  k: {t: vQ, type: low}
   l: [HD Promethium]
 - p: [8, 9]
   k: {t: zZ, type: low}

--- a/keymap-drawer/tc36k.svg
+++ b/keymap-drawer/tc36k.svg
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -173,18 +172,22 @@ text.right {
 <g transform="translate(28, 119)" class="key high keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">sS</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">nN</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">tT</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">hH</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(262, 169) rotate(22.0)" class="key low keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -197,34 +200,42 @@ text.right {
 <g transform="translate(505, 134) rotate(-22.0)" class="key high keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">aA</text>
+<text x="0" y="24" class="key high hold">⌘</text>
 </g>
 <g transform="translate(554, 88) rotate(-18.0)" class="key high keypos-17">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">eE</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(622, 93) rotate(-10.0)" class="key high keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">iI</text>
+<text x="0" y="24" class="key high hold">⎇</text>
 </g>
 <g transform="translate(692, 119)" class="key medium keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">cC</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(28, 175)" class="key medium-low keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
 <text x="0" y="0" class="key medium-low tap">bB</text>
+<text x="0" y="24" class="key medium-low hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">fF</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">dD</text>
+<text x="0" y="24" class="key medium-high hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">lL</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(242, 221) rotate(22.0)" class="key low keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
@@ -237,18 +248,22 @@ text.right {
 <g transform="translate(524, 186) rotate(-22.0)" class="key medium-high keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
 <text x="0" y="0" class="key medium-high tap">uU</text>
+<text x="0" y="24" class="key medium-high hold">⌘</text>
 </g>
 <g transform="translate(570, 142) rotate(-18.0)" class="key high keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">oO</text>
+<text x="0" y="24" class="key high hold">⌃</text>
 </g>
 <g transform="translate(632, 148) rotate(-10.0)" class="key medium keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">yY</text>
+<text x="0" y="24" class="key medium hold">⎇</text>
 </g>
 <g transform="translate(692, 175)" class="key medium keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
 <text x="0" y="0" class="key medium tap">wW</text>
+<text x="0" y="24" class="key medium hold">⇧</text>
 </g>
 <g transform="translate(143, 241) rotate(22.0)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -257,6 +272,7 @@ text.right {
 <g transform="translate(199, 274) rotate(37.0)" class="key high keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
 <text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
 </g>
 <g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -269,7 +285,7 @@ text.right {
 </g>
 <g transform="translate(521, 274) rotate(-37.0)" class="key high keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
-<text x="0" y="0" class="key high tap">⎵</text>
+<text x="0" y="0" class="key high tap">⎵R</text>
 <text x="0" y="24" class="key high hold">Num+Nav</text>
 </g>
 <g transform="translate(576, 241) rotate(-22.0)" class="key keypos-35">
@@ -323,133 +339,101 @@ text.right {
 <rect rx="6" ry="6" x="591" y="207" width="28" height="15" class="combo"/>
 <text x="605" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
-<text x="63" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
-<text x="657" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
-<text x="588" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-10">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-11">
-<rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
-<text x="529" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-12">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-13">
-<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
-<text x="547" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-6">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
-<text x="209" y="59" class="combo low tap">qQ</text>
+<text x="209" y="59" class="combo low tap">vQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-7">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
 <text x="575" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-8">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-9">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <path d="M360,274 l-142,0" class="combo"/>
 <path d="M360,274 l142,0" class="combo"/>
 <rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
 <text x="360" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-22">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
@@ -712,18 +696,22 @@ text.right {
 <g transform="translate(28, 119)" class="key keypos-10">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">*</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(97, 93) rotate(10.0)" class="key keypos-11">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">4</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(166, 88) rotate(18.0)" class="key keypos-12">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">5</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(215, 134) rotate(22.0)" class="key keypos-13">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">6</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(262, 169) rotate(22.0)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -748,24 +736,29 @@ text.right {
 <g transform="translate(692, 119)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">UP</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(28, 175)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">.</text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(88, 148) rotate(10.0)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">7</text>
+<text x="0" y="24" class="key hold">⎇</text>
 </g>
 <g transform="translate(150, 142) rotate(18.0)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">8</text>
+<text x="0" y="24" class="key hold">⌃</text>
 </g>
 <g transform="translate(195, 186) rotate(22.0)" class="key keypos-23">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">9</text>
+<text x="0" y="24" class="key hold">⌘</text>
 </g>
 <g transform="translate(242, 221) rotate(22.0)" class="key keypos-24">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -790,8 +783,9 @@ text.right {
 <g transform="translate(692, 175)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
+<tspan x="0" dy="-0.9em">VOL</tspan><tspan x="0" dy="1.2em">DOWN</tspan>
 </text>
+<text x="0" y="24" class="key hold">⇧</text>
 </g>
 <g transform="translate(143, 241) rotate(22.0)" class="key trans keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -832,110 +826,78 @@ text.right {
 <text x="605" y="214" class="combo tap">⏎</text>
 </g>
 <g class="combo combopos-2">
-<rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
-<text x="63" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-3">
-<rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
-<text x="657" y="106" class="combo tap">⎇</text>
-</g>
-<g class="combo combopos-4">
-<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
-<text x="132" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-5">
-<rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
-<text x="588" y="91" class="combo tap">⌃</text>
-</g>
-<g class="combo combopos-6">
-<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
-<text x="190" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-7">
-<rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
-<text x="529" y="111" class="combo tap">⌘</text>
-</g>
-<g class="combo combopos-8">
-<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
-<text x="172" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-9">
-<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
-<text x="547" y="164" class="combo tap">⇧</text>
-</g>
-<g class="combo combopos-10">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-7">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-8">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-9">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-10">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-11">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-12">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-13">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/tc36k.yaml
+++ b/keymap-drawer/tc36k.yaml
@@ -7,35 +7,35 @@ layers:
   - {t: mM, type: medium}
   - {t: xX, type: low}
   - {t: '/?', type: low}
-  - {t: ⌫, h: Sft+⌫}
+  - ⌫
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
   - {t: =+, type: low}
-  - {t: sS, type: high}
-  - {t: nN, type: high}
-  - {t: tT, type: high}
-  - {t: hH, type: high}
+  - {t: sS, h: ⇧, type: high}
+  - {t: nN, h: ⎇, type: high}
+  - {t: tT, h: ⌃, type: high}
+  - {t: hH, h: ⌘, type: high}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
-  - {t: aA, type: high}
-  - {t: eE, type: high}
-  - {t: iI, type: high}
-  - {t: cC, type: medium}
-  - {t: bB, type: medium-low}
-  - {t: fF, type: medium}
-  - {t: dD, type: medium-high}
-  - {t: lL, type: medium-high}
+  - {t: aA, h: ⌘, type: high}
+  - {t: eE, h: ⌃, type: high}
+  - {t: iI, h: ⎇, type: high}
+  - {t: cC, h: ⇧, type: medium}
+  - {t: bB, h: ⇧, type: medium-low}
+  - {t: fF, h: ⎇, type: medium}
+  - {t: dD, h: ⌃, type: medium-high}
+  - {t: lL, h: ⌘, type: medium-high}
   - {t: jJ, type: low}
   - {t: ',;', type: medium-low}
-  - {t: uU, type: medium-high}
-  - {t: oO, type: high}
-  - {t: yY, type: medium}
-  - {t: wW, type: medium}
+  - {t: uU, h: ⌘, type: medium-high}
+  - {t: oO, h: ⌃, type: high}
+  - {t: yY, h: ⎇, type: medium}
+  - {t: wW, h: ⇧, type: medium}
   - ↹
-  - {t: rR, type: high}
+  - {t: rR, h: ⇧, type: high}
   - {t: ⌫, h: ⇧}
   - ⇧
-  - {t: ⎵, h: Num+Nav, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
   - Num + Nav
   Naginata:
   - {t: ⎋, h: Small-kana}
@@ -85,30 +85,30 @@ layers:
   - ↑
   - _
   - ⏯
-  - '*'
-  - '4'
-  - '5'
-  - '6'
+  - {t: '*', h: ⇧}
+  - {t: '4', h: ⎇}
+  - {t: '5', h: ⌃}
+  - {t: '6', h: ⌘}
   - +
   - ⇞
   - ←
   - ↓
   - →
-  - 'VOL
+  - {t: 'VOL
 
-    UP'
-  - .
-  - '7'
-  - '8'
-  - '9'
+      UP', h: ⇧}
+  - {t: ., h: ⇧}
+  - {t: '7', h: ⎇}
+  - {t: '8', h: ⌃}
+  - {t: '9', h: ⌘}
   - '-'
   - ⇟
   - ↞
   - ⏎
   - ↠
-  - 'VOL
+  - {t: 'VOL
 
-    DOWN'
+      DOWN', h: ⇧}
   - {t: ▽, type: trans}
   - {t: '0', h: ⇧}
   - {t: ▽, type: trans}
@@ -152,32 +152,8 @@ combos:
   o: -0.02
   s: 0.5
   h: 15.0
-- p: [11, 10]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [18, 19]
-  k: ⎇
-  l: [HD Promethium, Num + Nav]
-- p: [12, 11]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [17, 18]
-  k: ⌃
-  l: [HD Promethium, Num + Nav]
-- p: [13, 12]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [16, 17]
-  k: ⌘
-  l: [HD Promethium, Num + Nav]
-- p: [23, 22]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
-- p: [26, 27]
-  k: ⇧
-  l: [HD Promethium, Num + Nav]
 - p: [3, 2]
-  k: {t: qQ, type: low}
+  k: {t: vQ, type: low}
   l: [HD Promethium]
 - p: [7, 8]
   k: {t: zZ, type: low}

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -157,7 +157,7 @@ parse_config:
     # These are the English letters defined here to tag them by usage:
     '&hmr LGUI A': {'t': 'aA', 'type': 'high', 'h': '⌘'}
     '&hml RSHFT B': {'t': 'bB', 'type': 'medium-low', 'h': '⇧'}
-    '&hmr LSHFT C': {'t': 'cC', 'type': 'medium', 'h': '⇧'}
+    '&hmr RSHFT C': {'t': 'cC', 'type': 'medium', 'h': '⇧'}
     '&hml RCTRL D': {'t': 'dD', 'type': 'medium-high', 'h': '⌃'}
     '&hmr LCTRL E': {'t': 'eE', 'type': 'high', 'h': '⌃'}
     '&hml RALT F': {'t': 'fF', 'type': 'medium', 'h': '⎇'}
@@ -173,7 +173,7 @@ parse_config:
     '&kp P': {'t': 'pP', 'type': 'medium-low'}
     '&kp Q': {'t': 'vQ', 'type': 'low'}
     '&kp R': {'t': 'rR', 'type': 'high'}
-    '&hml LSHFT S': {'t': 'sS', 'type': 'high', 'h': '⇧'}
+    '&hml RSHFT S': {'t': 'sS', 'type': 'high', 'h': '⇧'}
     '&hml LCTRL T': {'t': 'tT', 'type': 'high', 'h': '⌃'}
     '&hmr RGUI U': {'t': 'uU', 'type': 'medium-high', 'h': '⌘'}
     '&kp V': {'t': 'vV', 'type': 'low'}
@@ -195,6 +195,7 @@ parse_config:
     '&kp EQUAL': {'t': '=+', 'type': 'low'}
     '&kp SPACE': {'t': '⎵', 'type': 'high'}
     '&blt NUM_NAV SPACE': {'t': '⎵', 'h': 'Num+Nav', 'type': 'high'}
+    '&space_R_layer NUM_NAV 0': {'t': '⎵R', 'h': 'Num+Nav', 'type': 'high'}
     # And again for auto-shift:
     'AS(A)': {'t': 'aA', 'type': 'high'}
     'AS(B)': {'t': 'bB', 'type': 'medium-low'}

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -155,31 +155,31 @@ parse_config:
     close_square_curly: {'key': ']}'}
   raw_binding_map:
     # These are the English letters defined here to tag them by usage:
-    '&kp A': {'t': 'aA', 'type': 'high'}
-    '&kp B': {'t': 'bB', 'type': 'medium-low'}
-    '&kp C': {'t': 'cC', 'type': 'medium'}
-    '&kp D': {'t': 'dD', 'type': 'medium-high'}
-    '&kp E': {'t': 'eE', 'type': 'high'}
-    '&kp F': {'t': 'fF', 'type': 'medium'}
+    '&hmr LGUI A': {'t': 'aA', 'type': 'high', 'h': '⌘'}
+    '&hml RSHFT B': {'t': 'bB', 'type': 'medium-low', 'h': '⇧'}
+    '&hmr LSHFT C': {'t': 'cC', 'type': 'medium', 'h': '⇧'}
+    '&hml RCTRL D': {'t': 'dD', 'type': 'medium-high', 'h': '⌃'}
+    '&hmr LCTRL E': {'t': 'eE', 'type': 'high', 'h': '⌃'}
+    '&hml RALT F': {'t': 'fF', 'type': 'medium', 'h': '⎇'}
     '&kp G': {'t': 'gG', 'type': 'medium'}
-    '&kp H': {'t': 'hH', 'type': 'high'}
-    '&kp I': {'t': 'iI', 'type': 'high'}
+    '&hml LGUI H': {'t': 'hH', 'type': 'high', 'h': '⌘'}
+    '&hmr LALT I': {'t': 'iI', 'type': 'high', 'h': '⎇'}
     '&kp J': {'t': 'jJ', 'type': 'low'}
     '&kp K': {'t': 'kK', 'type': 'low'}
-    '&kp L': {'t': 'lL', 'type': 'medium-high'}
+    '&hml RGUI L': {'t': 'lL', 'type': 'medium-high', 'h': '⌘'}
     '&kp M': {'t': 'mM', 'type': 'medium'}
-    '&kp N': {'t': 'nN', 'type': 'high'}
-    '&kp O': {'t': 'oO', 'type': 'high'}
+    '&hml LALT N': {'t': 'nN', 'type': 'high', 'h': '⎇'}
+    '&hmr RCTRL O': {'t': 'oO', 'type': 'high', 'h': '⌃'}
     '&kp P': {'t': 'pP', 'type': 'medium-low'}
     '&kp Q': {'t': 'vQ', 'type': 'low'}
     '&kp R': {'t': 'rR', 'type': 'high'}
-    '&kp S': {'t': 'sS', 'type': 'high'}
-    '&kp T': {'t': 'tT', 'type': 'high'}
-    '&kp U': {'t': 'uU', 'type': 'medium-high'}
+    '&hml LSHFT S': {'t': 'sS', 'type': 'high', 'h': '⇧'}
+    '&hml LCTRL T': {'t': 'tT', 'type': 'high', 'h': '⌃'}
+    '&hmr RGUI U': {'t': 'uU', 'type': 'medium-high', 'h': '⌘'}
     '&kp V': {'t': 'vV', 'type': 'low'}
-    '&kp W': {'t': 'wW', 'type': 'medium'}
+    '&hmr RSHFT W': {'t': 'wW', 'type': 'medium', 'h': '⇧'}
     '&kp X': {'t': 'xX', 'type': 'low'}
-    '&kp Y': {'t': 'yY', 'type': 'medium'}
+    '&hmr RALT Y': {'t': 'yY', 'type': 'medium', 'h': '⎇'}
     '&kp Z': {'t': 'zZ', 'type': 'low'}
     '&kp COMMA': {'t': ',<', 'type': 'medium-low'}
     '&kp SEMI': {'t': ';:', 'type': 'low'}

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -172,7 +172,7 @@ parse_config:
     '&hmr RCTRL O': {'t': 'oO', 'type': 'high', 'h': '⌃'}
     '&kp P': {'t': 'pP', 'type': 'medium-low'}
     '&kp Q': {'t': 'vQ', 'type': 'low'}
-    '&kp R': {'t': 'rR', 'type': 'high'}
+    '&bmt LSHFT R': {'t': 'rR', 'type': 'high', 'h': '⇧'}
     '&hml RSHFT S': {'t': 'sS', 'type': 'high', 'h': '⇧'}
     '&hml LCTRL T': {'t': 'tT', 'type': 'high', 'h': '⌃'}
     '&hmr RGUI U': {'t': 'uU', 'type': 'medium-high', 'h': '⌘'}


### PR DESCRIPTION
I love the _idea_ of autoshift (long presses for capitals), and it works nicely with two-key horizontal combos for the modifiers. It worked well with a thumb shift on the nav layer too. The combo shift for mouse use was a little awkward. However, I struggled with using too much pressure bottoming out the keys for capitals - which I think was making it uncomfortable to use.

So after giving up on this second round of using autoshift, this goes back to left-thumb-shift and special casing capital R (as in #32).

This also lets me replace the HRM combos with the more typical [ZMK timeless HRM by Urob](https://github.com/urob/zmk-config/tree/main?tab=readme-ov-file#timeless-homerow-mods), rather than adding shift as a bottom row combo. On the grounds that the left-thumb will be the primary shift, for the HRM shift is placed on the pinkies (familiar from Qwerty too). Then alt (ring), ctrl (middle), gui (index) as per my combo ordering with macOS in mind.