### PR TITLE
Stacked modifiers using home-row combos

### DIFF
--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -448,6 +448,49 @@
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
+        // Stacked modifiers with 3 or 4 keys
+        left_ctrl_gui_combo {
+            bindings = <&kp LC(LGUI)>;
+            key-positions = <LM1 LM2 LM3>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
+        right_ctrl_gui_combo {
+            bindings = <&kp RC(RGUI)>;
+            key-positions = <RM1 RM2 RM3>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
+        left_ctrl_alt_combo {
+            bindings = <&kp LC(LALT)>;
+            key-positions = <LM2 LM3 LM4>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
+        right_ctrl_alt_combo {
+            bindings = <&kp RC(RALT)>;
+            key-positions = <RM2 RM3 RM4>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
+        left_ctrl_alt_gui_combo {
+            bindings = <&kp LC(LA(LGUI))>;
+            key-positions = <LM1 LM2 LM3 LM4>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
+        right_ctrl_alt_gui_combo {
+            bindings = <&kp RC(RA(RGUI))>;
+            key-positions = <RM1 RM2 RM3 RM4>;
+            layers = <DEFAULT NUM_NAV>;
+            require-prior-idle-ms = <250>;
+            timeout-ms = <40>;
+        };
 
         // 2-key horizontal bottom-row combos for shift
         left_shift_combo {

--- a/keymap-drawer/acid.svg
+++ b/keymap-drawer/acid.svg
@@ -337,109 +337,109 @@ text.right {
 <rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
 <text x="532" y="89" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
 <text x="168" y="145" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
 <text x="532" y="145" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo low"/>
 <text x="168" y="33" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo low"/>
 <text x="588" y="36" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo low"/>
 <text x="112" y="36" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="98" y="135" width="28" height="26" class="combo low"/>
 <text x="112" y="148" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <path d="M350,224 l-79,0" class="combo"/>
 <path d="M350,224 l79,0" class="combo"/>
 <rect rx="6" ry="6" x="336" y="211" width="28" height="26" class="combo"/>
 <text x="350" y="224" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
 <text x="28" y="90" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
 <text x="84" y="72" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
 <text x="140" y="56" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
 <text x="196" y="66" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="238" y="59" width="28" height="26" class="combo"/>
 <text x="252" y="72" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M281,128 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M281,128 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
 <rect rx="6" ry="6" x="267" y="115" width="28" height="26" class="combo"/>
 <text x="281" y="128" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M419,128 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M419,128 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
 <rect rx="6" ry="6" x="405" y="115" width="28" height="26" class="combo"/>
 <text x="419" y="128" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="434" y="59" width="28" height="26" class="combo"/>
 <text x="448" y="72" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
 <text x="504" y="66" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
 <text x="560" y="56" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
 <text x="616" y="72" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
 <text x="672" y="90" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
 <text x="224" y="41" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
 <text x="476" y="41" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
 <text x="224" y="97" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
 <text x="476" y="97" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
 <text x="224" y="153" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
 <text x="476" y="153" class="combo tap">]}</text>
 </g>
@@ -826,112 +826,112 @@ text.right {
 <rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
 <text x="532" y="89" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
 <text x="168" y="145" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
 <text x="532" y="145" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
 <text x="28" y="90" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
 <text x="84" y="72" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
 <text x="140" y="56" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
 <text x="196" y="66" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="238" y="59" width="28" height="26" class="combo"/>
 <text x="252" y="72" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M281,128 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M281,128 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
 <rect rx="6" ry="6" x="267" y="115" width="28" height="26" class="combo"/>
 <text x="281" y="128" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M419,128 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M419,128 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
 <rect rx="6" ry="6" x="405" y="115" width="28" height="26" class="combo"/>
 <text x="419" y="128" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="434" y="59" width="28" height="26" class="combo"/>
 <text x="448" y="72" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
 <text x="504" y="66" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
 <text x="560" y="56" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
 <text x="616" y="72" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
 <text x="672" y="90" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
 <text x="224" y="41" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
 <text x="476" y="41" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
 <text x="224" y="97" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
 <text x="476" y="97" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
 <text x="224" y="153" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
 <text x="476" y="153" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="42" y="40" width="28" height="26" class="combo"/>
 <text x="56" y="53" class="combo tap">BT</text>
 <text x="56" y="64" class="combo hold">0</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo"/>
 <text x="112" y="36" class="combo tap">BT</text>
 <text x="112" y="47" class="combo hold">1</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo"/>
 <text x="168" y="33" class="combo tap">BT</text>
 <text x="168" y="44" class="combo hold">2</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="518" y="20" width="28" height="26" class="combo"/>
 <text x="532" y="33" class="combo tap">
 <tspan x="532" dy="-0.6em">BT</tspan><tspan x="532" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo"/>
 <text x="588" y="36" class="combo tap">
 <tspan x="588" dy="-0.6em">BT</tspan><tspan x="588" dy="1.2em">…</tspan>

--- a/keymap-drawer/acid.yaml
+++ b/keymap-drawer/acid.yaml
@@ -165,6 +165,30 @@ combos:
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [13, 12, 11]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [12, 11, 10]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 18, 19]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [13, 12, 11, 10]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18, 19]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [23, 22]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap-drawer/bivouac34.svg
+++ b/keymap-drawer/bivouac34.svg
@@ -329,109 +329,109 @@ text.right {
 <rect rx="6" ry="6" x="479" y="98" width="28" height="26" class="combo"/>
 <text x="493" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="497" y="151" width="28" height="26" class="combo"/>
 <text x="511" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
 <text x="209" y="59" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="525" y="24" width="28" height="26" class="combo low"/>
 <text x="539" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <path d="M342,267 l-123,0" class="combo"/>
 <path d="M342,267 l123,0" class="combo"/>
 <rect rx="6" ry="6" x="328" y="254" width="28" height="26" class="combo"/>
 <text x="342" y="267" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M377,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M377,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="363" y="143" width="28" height="26" class="combo"/>
 <text x="377" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="413" y="93" width="28" height="26" class="combo"/>
 <text x="427" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="444" y="95" width="28" height="26" class="combo"/>
 <text x="458" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="495" y="49" width="28" height="26" class="combo"/>
 <text x="509" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="568" y="53" width="28" height="26" class="combo"/>
 <text x="582" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="632" y="79" width="28" height="26" class="combo"/>
 <text x="646" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="423" y="119" width="28" height="26" class="combo"/>
 <text x="437" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="433" y="145" width="28" height="26" class="combo"/>
 <text x="447" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="443" y="171" width="28" height="26" class="combo"/>
 <text x="457" y="184" class="combo tap">]}</text>
 </g>
@@ -802,87 +802,87 @@ text.right {
 <rect rx="6" ry="6" x="479" y="98" width="28" height="26" class="combo"/>
 <text x="493" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="497" y="151" width="28" height="26" class="combo"/>
 <text x="511" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M377,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M377,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="363" y="143" width="28" height="26" class="combo"/>
 <text x="377" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="413" y="93" width="28" height="26" class="combo"/>
 <text x="427" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="444" y="95" width="28" height="26" class="combo"/>
 <text x="458" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="495" y="49" width="28" height="26" class="combo"/>
 <text x="509" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="568" y="53" width="28" height="26" class="combo"/>
 <text x="582" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="632" y="79" width="28" height="26" class="combo"/>
 <text x="646" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="423" y="119" width="28" height="26" class="combo"/>
 <text x="437" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="433" y="145" width="28" height="26" class="combo"/>
 <text x="447" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="443" y="171" width="28" height="26" class="combo"/>
 <text x="457" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivouac34.yaml
+++ b/keymap-drawer/bivouac34.yaml
@@ -159,6 +159,30 @@ combos:
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [13, 12, 11]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [12, 11, 10]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 18, 19]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [13, 12, 11, 10]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18, 19]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [23, 22]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap-drawer/bivvy16d.svg
+++ b/keymap-drawer/bivvy16d.svg
@@ -362,109 +362,109 @@ text.right {
 <rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
 <text x="507" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
 <text x="525" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
 <text x="209" y="59" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="539" y="24" width="28" height="26" class="combo low"/>
 <text x="553" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <path d="M349,276 l-72,1" class="combo"/>
 <path d="M349,276 l72,-1" class="combo"/>
 <rect rx="6" ry="6" x="335" y="263" width="28" height="26" class="combo"/>
 <text x="349" y="276" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
 <text x="391" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
 <text x="441" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
 <text x="472" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
 <text x="523" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
 <text x="596" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
 <text x="660" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
 <text x="451" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
 <text x="461" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
 <text x="471" y="184" class="combo tap">]}</text>
 </g>
@@ -902,87 +902,87 @@ text.right {
 <rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
 <text x="507" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
 <text x="525" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
 <text x="391" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
 <text x="441" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
 <text x="472" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
 <text x="523" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
 <text x="596" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
 <text x="660" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
 <text x="451" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
 <text x="461" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
 <text x="471" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivvy16d.yaml
+++ b/keymap-drawer/bivvy16d.yaml
@@ -183,6 +183,30 @@ combos:
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [13, 12, 11]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [12, 11, 10]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 18, 19]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [13, 12, 11, 10]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18, 19]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [23, 22]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap-drawer/goldilocks32.svg
+++ b/keymap-drawer/goldilocks32.svg
@@ -340,107 +340,107 @@ text.right {
 <rect rx="6" ry="6" x="478" y="102" width="28" height="26" class="combo"/>
 <text x="492" y="115" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
 <text x="172" y="169" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="496" y="156" width="28" height="26" class="combo"/>
 <text x="510" y="169" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="193" y="47" width="28" height="26" class="combo low"/>
 <text x="207" y="60" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="524" y="24" width="28" height="26" class="combo low"/>
 <text x="538" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="105" y="136" width="28" height="26" class="combo low"/>
 <text x="119" y="149" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="327" y="261" width="28" height="26" class="combo"/>
 <text x="341" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
 <text x="37" y="98" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
 <text x="101" y="67" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
 <text x="174" y="63" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
 <text x="224" y="112" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
 <text x="255" y="110" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
 <rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
 <text x="305" y="162" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M377,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M377,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
 <rect rx="6" ry="6" x="363" y="149" width="28" height="26" class="combo"/>
 <text x="377" y="162" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="413" y="97" width="28" height="26" class="combo"/>
 <text x="427" y="110" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="444" y="99" width="28" height="26" class="combo"/>
 <text x="458" y="112" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="494" y="50" width="28" height="26" class="combo"/>
 <text x="508" y="63" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="567" y="54" width="28" height="26" class="combo"/>
 <text x="581" y="67" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="631" y="85" width="28" height="26" class="combo"/>
 <text x="645" y="98" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
 <text x="245" y="137" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="423" y="124" width="28" height="26" class="combo"/>
 <text x="437" y="137" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
 <text x="236" y="164" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="432" y="151" width="28" height="26" class="combo"/>
 <text x="446" y="164" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
 <text x="226" y="191" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="442" y="178" width="28" height="26" class="combo"/>
 <text x="456" y="191" class="combo tap">]}</text>
 </g>
@@ -834,87 +834,87 @@ text.right {
 <rect rx="6" ry="6" x="478" y="102" width="28" height="26" class="combo"/>
 <text x="492" y="115" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
 <text x="172" y="169" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="496" y="156" width="28" height="26" class="combo"/>
 <text x="510" y="169" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
 <text x="37" y="98" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
 <text x="101" y="67" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
 <text x="174" y="63" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
 <text x="224" y="112" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
 <text x="255" y="110" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
 <rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
 <text x="305" y="162" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M377,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M377,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
 <rect rx="6" ry="6" x="363" y="149" width="28" height="26" class="combo"/>
 <text x="377" y="162" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="413" y="97" width="28" height="26" class="combo"/>
 <text x="427" y="110" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="444" y="99" width="28" height="26" class="combo"/>
 <text x="458" y="112" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="494" y="50" width="28" height="26" class="combo"/>
 <text x="508" y="63" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="567" y="54" width="28" height="26" class="combo"/>
 <text x="581" y="67" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="631" y="85" width="28" height="26" class="combo"/>
 <text x="645" y="98" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
 <text x="245" y="137" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="423" y="124" width="28" height="26" class="combo"/>
 <text x="437" y="137" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
 <text x="236" y="164" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="432" y="151" width="28" height="26" class="combo"/>
 <text x="446" y="164" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
 <text x="226" y="191" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="442" y="178" width="28" height="26" class="combo"/>
 <text x="456" y="191" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/goldilocks32.yaml
+++ b/keymap-drawer/goldilocks32.yaml
@@ -168,6 +168,30 @@ combos:
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [13, 12, 11]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [12, 11, 10]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 18, 19]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [13, 12, 11, 10]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18, 19]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [23, 22]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap-drawer/hesse.svg
+++ b/keymap-drawer/hesse.svg
@@ -348,109 +348,109 @@ text.right {
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
 <text x="547" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
 <text x="209" y="59" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
 <text x="575" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <path d="M360,274 l-142,0" class="combo"/>
 <path d="M360,274 l142,0" class="combo"/>
 <rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
 <text x="360" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
@@ -855,112 +855,112 @@ text.right {
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
 <text x="547" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="53" y="37" width="28" height="26" class="combo"/>
 <text x="67" y="50" class="combo tap">BT</text>
 <text x="67" y="61" class="combo hold">0</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo"/>
 <text x="144" y="37" class="combo tap">BT</text>
 <text x="144" y="48" class="combo hold">1</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo"/>
 <text x="209" y="59" class="combo tap">BT</text>
 <text x="209" y="70" class="combo hold">2</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="497" y="46" width="28" height="26" class="combo"/>
 <text x="511" y="59" class="combo tap">
 <tspan x="511" dy="-0.6em">BT</tspan><tspan x="511" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo"/>
 <text x="575" y="37" class="combo tap">
 <tspan x="575" dy="-0.6em">BT</tspan><tspan x="575" dy="1.2em">…</tspan>

--- a/keymap-drawer/hesse.yaml
+++ b/keymap-drawer/hesse.yaml
@@ -171,6 +171,30 @@ combos:
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [13, 12, 11]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [12, 11, 10]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 18, 19]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [13, 12, 11, 10]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18, 19]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [23, 22]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap-drawer/rugby_union.svg
+++ b/keymap-drawer/rugby_union.svg
@@ -320,109 +320,109 @@ text.right {
 <rect rx="6" ry="6" x="505" y="144" width="28" height="26" class="combo"/>
 <text x="519" y="157" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="163" y="184" width="28" height="26" class="combo"/>
 <text x="177" y="197" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="539" y="185" width="28" height="26" class="combo"/>
 <text x="553" y="198" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="232" y="103" width="28" height="26" class="combo low"/>
 <text x="246" y="116" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="522" y="58" width="28" height="26" class="combo low"/>
 <text x="536" y="71" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="182" y="58" width="28" height="26" class="combo low"/>
 <text x="196" y="71" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="120" y="145" width="28" height="26" class="combo low"/>
 <text x="134" y="158" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <path d="M365,328 l-123,0" class="combo"/>
 <path d="M365,328 l123,0" class="combo"/>
 <rect rx="6" ry="6" x="351" y="315" width="28" height="26" class="combo"/>
 <text x="365" y="328" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="63" y="66" width="28" height="26" class="combo"/>
 <text x="77" y="79" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="132" y="68" width="28" height="26" class="combo"/>
 <text x="146" y="81" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="200" y="92" width="28" height="26" class="combo"/>
 <text x="214" y="105" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="230" y="155" width="28" height="26" class="combo"/>
 <text x="244" y="168" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="259" y="166" width="28" height="26" class="combo"/>
 <text x="273" y="179" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M314,229 v-14 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M314,229 v14 a6.0,6.0 0 0 1 -6.0,6.0 h-40" class="combo"/>
 <rect rx="6" ry="6" x="300" y="216" width="28" height="26" class="combo"/>
 <text x="314" y="229" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M417,229 v-14 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M417,229 v14 a6.0,6.0 0 0 0 6.0,6.0 h40" class="combo"/>
 <rect rx="6" ry="6" x="403" y="216" width="28" height="26" class="combo"/>
 <text x="417" y="229" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="444" y="166" width="28" height="26" class="combo"/>
 <text x="458" y="179" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="473" y="156" width="28" height="26" class="combo"/>
 <text x="487" y="169" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="503" y="92" width="28" height="26" class="combo"/>
 <text x="517" y="105" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="571" y="68" width="28" height="26" class="combo"/>
 <text x="585" y="81" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="639" y="66" width="28" height="26" class="combo"/>
 <text x="653" y="79" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="241" y="186" width="28" height="26" class="combo"/>
 <text x="255" y="199" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="461" y="186" width="28" height="26" class="combo"/>
 <text x="475" y="199" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="223" y="205" width="28" height="26" class="combo"/>
 <text x="237" y="218" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="479" y="205" width="28" height="26" class="combo"/>
 <text x="493" y="218" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="206" y="225" width="28" height="26" class="combo"/>
 <text x="220" y="238" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="497" y="225" width="28" height="26" class="combo"/>
 <text x="511" y="238" class="combo tap">]}</text>
 </g>
@@ -776,87 +776,87 @@ text.right {
 <rect rx="6" ry="6" x="505" y="144" width="28" height="26" class="combo"/>
 <text x="519" y="157" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="163" y="184" width="28" height="26" class="combo"/>
 <text x="177" y="197" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="539" y="185" width="28" height="26" class="combo"/>
 <text x="553" y="198" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="63" y="66" width="28" height="26" class="combo"/>
 <text x="77" y="79" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="132" y="68" width="28" height="26" class="combo"/>
 <text x="146" y="81" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="200" y="92" width="28" height="26" class="combo"/>
 <text x="214" y="105" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="230" y="155" width="28" height="26" class="combo"/>
 <text x="244" y="168" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="259" y="166" width="28" height="26" class="combo"/>
 <text x="273" y="179" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M314,229 v-14 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M314,229 v14 a6.0,6.0 0 0 1 -6.0,6.0 h-40" class="combo"/>
 <rect rx="6" ry="6" x="300" y="216" width="28" height="26" class="combo"/>
 <text x="314" y="229" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M417,229 v-14 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M417,229 v14 a6.0,6.0 0 0 0 6.0,6.0 h40" class="combo"/>
 <rect rx="6" ry="6" x="403" y="216" width="28" height="26" class="combo"/>
 <text x="417" y="229" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="444" y="166" width="28" height="26" class="combo"/>
 <text x="458" y="179" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="473" y="156" width="28" height="26" class="combo"/>
 <text x="487" y="169" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="503" y="92" width="28" height="26" class="combo"/>
 <text x="517" y="105" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="571" y="68" width="28" height="26" class="combo"/>
 <text x="585" y="81" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="639" y="66" width="28" height="26" class="combo"/>
 <text x="653" y="79" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="241" y="186" width="28" height="26" class="combo"/>
 <text x="255" y="199" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="461" y="186" width="28" height="26" class="combo"/>
 <text x="475" y="199" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="223" y="205" width="28" height="26" class="combo"/>
 <text x="237" y="218" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="479" y="205" width="28" height="26" class="combo"/>
 <text x="493" y="218" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="206" y="225" width="28" height="26" class="combo"/>
 <text x="220" y="238" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="497" y="225" width="28" height="26" class="combo"/>
 <text x="511" y="238" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/rugby_union.yaml
+++ b/keymap-drawer/rugby_union.yaml
@@ -153,6 +153,30 @@ combos:
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [13, 12, 11]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [12, 11, 10]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 18, 19]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [13, 12, 11, 10]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18, 19]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [23, 22]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap-drawer/slump52.svg
+++ b/keymap-drawer/slump52.svg
@@ -411,107 +411,107 @@ text.right {
 <rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
 <text x="489" y="116" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
 <text x="180" y="168" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
 <text x="514" y="168" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="216" y="53" width="28" height="26" class="combo low"/>
 <text x="230" y="66" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="505" y="33" width="28" height="26" class="combo low"/>
 <text x="519" y="46" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="160" y="33" width="28" height="26" class="combo low"/>
 <text x="174" y="46" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="106" y="137" width="28" height="26" class="combo low"/>
 <text x="120" y="150" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="333" y="245" width="28" height="26" class="combo"/>
 <text x="347" y="258" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
 <text x="28" y="112" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
 <text x="124" y="63" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
 <text x="190" y="80" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
 <text x="244" y="102" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
 <text x="276" y="102" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
 <rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
 <text x="324" y="151" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
 <rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
 <text x="370" y="151" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
 <text x="418" y="102" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
 <text x="449" y="102" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
 <text x="504" y="80" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
 <text x="570" y="63" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
 <text x="666" y="112" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
 <text x="264" y="127" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
 <text x="430" y="127" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
 <text x="252" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
 <text x="442" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
 <text x="240" y="178" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
 <text x="454" y="178" class="combo tap">]}</text>
 </g>
@@ -1048,87 +1048,87 @@ text.right {
 <rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
 <text x="489" y="116" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
 <text x="180" y="168" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
 <text x="514" y="168" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
 <text x="28" y="112" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
 <text x="124" y="63" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
 <text x="190" y="80" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
 <text x="244" y="102" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
 <text x="276" y="102" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
 <rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
 <text x="324" y="151" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
 <rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
 <text x="370" y="151" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
 <text x="418" y="102" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
 <text x="449" y="102" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
 <text x="504" y="80" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
 <text x="570" y="63" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
 <text x="666" y="112" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
 <text x="264" y="127" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
 <text x="430" y="127" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
 <text x="252" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
 <text x="442" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
 <text x="240" y="178" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
 <text x="454" y="178" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/slump52.yaml
+++ b/keymap-drawer/slump52.yaml
@@ -219,6 +219,30 @@ combos:
 - p: [21, 22]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [18, 17, 16]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [21, 22, 23]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 16, 28]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [22, 23, 37]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [18, 17, 16, 28]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [21, 22, 23, 37]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [31, 30]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap-drawer/tc36k.svg
+++ b/keymap-drawer/tc36k.svg
@@ -348,109 +348,109 @@ text.right {
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
 <text x="547" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo low combopos-14">
+<g class="combo low combopos-20">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
 <text x="209" y="59" class="combo low tap">qQ</text>
 </g>
-<g class="combo low combopos-15">
+<g class="combo low combopos-21">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
 <text x="575" y="37" class="combo low tap">zZ</text>
 </g>
-<g class="combo low combopos-16">
+<g class="combo low combopos-22">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
 <text x="144" y="37" class="combo low tap">vV</text>
 </g>
-<g class="combo low combopos-17">
+<g class="combo low combopos-23">
 <rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
 <text x="119" y="145" class="combo low tap">xX</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <path d="M360,274 l-142,0" class="combo"/>
 <path d="M360,274 l142,0" class="combo"/>
 <rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
 <text x="360" y="274" class="combo tap">⇪</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-38">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-39">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-40">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-41">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-42">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
@@ -855,87 +855,87 @@ text.right {
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-8">
+<g class="combo combopos-14">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-9">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
 <text x="547" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-10">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-11">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-12">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-13">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="258" y="130" width="28" height="26" class="combo"/>
 <text x="272" y="143" class="combo tap">\</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-21">
 <path d="M291,195 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M291,195 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="277" y="182" width="28" height="26" class="combo"/>
 <text x="291" y="195" class="combo tap">%</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-22">
 <path d="M429,195 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M429,195 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="415" y="182" width="28" height="26" class="combo"/>
 <text x="429" y="195" class="combo tap">^</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="433" y="130" width="28" height="26" class="combo"/>
 <text x="447" y="143" class="combo tap">/</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-24">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">{</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">}</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/tc36k.yaml
+++ b/keymap-drawer/tc36k.yaml
@@ -171,6 +171,30 @@ combos:
 - p: [16, 17]
   k: ⌘
   l: [HD Promethium, Num + Nav]
+- p: [13, 12, 11]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18]
+  k: Ctl+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [12, 11, 10]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [17, 18, 19]
+  k: Ctl+⎇
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [13, 12, 11, 10]
+  k: Ctl+Alt+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
+- p: [16, 17, 18, 19]
+  k: Ctl+AltGr+⌘
+  l: [HD Promethium, Num + Nav]
+  hidden: true
 - p: [23, 22]
   k: ⇧
   l: [HD Promethium, Num + Nav]

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -153,6 +153,13 @@ parse_config:
     close_bracket_greater_than: {'key': ')>'}
     open_square_curly: {'key': '[{'}
     close_square_curly: {'key': ']}'}
+    # Hide the stacked modifier combos
+    left_ctrl_gui_combo: {'hidden': true}
+    right_ctrl_gui_combo: {'hidden': true}
+    left_ctrl_alt_combo: {'hidden': true}
+    right_ctrl_alt_combo: {'hidden': true}
+    left_ctrl_alt_gui_combo: {'hidden': true}
+    right_ctrl_alt_gui_combo: {'hidden': true}
   raw_binding_map:
     # These are the English letters defined here to tag them by usage:
     '&kp A': {'t': 'aA', 'type': 'high'}


### PR DESCRIPTION
Adds the logical three and four key combos on the home-row extending the existing two key combos for alt, ctrl, and command (gui).

Should still be able to do alt and command as a two step pair of two-key combos. Doing all four fingers together will now give alt+ctrl+command.