### PR TITLE
Redefine combos and alias for inner columns dropping LB0/RB0 (bottom)

### DIFF
--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -344,11 +344,11 @@
             layers = <DEFAULT>;
         };
 
-#ifndef LT0
-        // Inner column corners on 32-style  (T, G, B, N) = &bootloader
+#ifndef LB0
+        // Inner column corners on 32-style  (T, Y, G, H) = &bootloader
         combo_bootloader {
             timeout-ms = <300>;
-            key-positions = <LM0 RM0 LB0 RB0>;
+            key-positions = <LM0 RM0 LT0 RT0>;
             bindings = <&bootloader>;
             layers = <DEFAULT>;
         };
@@ -555,19 +555,7 @@
             layers = <DEFAULT NUM_NAV>;
         };
 
-#ifndef LT0
-        backslash_sign {
-            bindings = <&kp NON_US_BACKSLASH>;
-            key-positions = <LT1 LM0>;
-            layers = <DEFAULT NUM_NAV>;
-        };
-        percent_sign {
-            bindings = <&kp PERCENT>;
-            key-positions = <LM0 LB0>;
-            layers = <DEFAULT NUM_NAV>;
-        };
-#else
-        backslash_sign {
+       backslash_sign {
             bindings = <&kp NON_US_BACKSLASH>;
             key-positions = <LT0 LT1>;
             layers = <DEFAULT NUM_NAV>;
@@ -578,23 +566,8 @@
             key-positions = <LT0 LM0>;
             layers = <DEFAULT NUM_NAV>;
         };
-#endif
 
-#ifndef RT0
-        slash_sign {
-            bindings = <&kp SLASH>;
-            key-positions = <RT1 RM0>;
-            layers = <DEFAULT NUM_NAV>;
-        };
-
-        caret_sign {
-            bindings = <&kp CARET>;
-            key-positions = <RM0 RB0>;
-            layers = <DEFAULT NUM_NAV>;
-        };
-
-#else
-        slash_sign {
+       slash_sign {
             bindings = <&kp SLASH>;
             key-positions = <RT1 RT0>;
             layers = <DEFAULT NUM_NAV>;
@@ -605,8 +578,6 @@
             key-positions = <RT0 RM0>;
             layers = <DEFAULT NUM_NAV>;
         };
-
-#endif
 
         question_mark {
             bindings = <&kp QMARK>;
@@ -633,35 +604,23 @@
         };
 
         // 2-key horizontal combos for {}, can instead use shift with the [] combos:
-#ifndef LT0
+        // (not comfortable enough to use with 3-key inner columns)
+#ifndef LB0
         open_curly {
             bindings = <&kp LEFT_BRACE>;
-            key-positions = <LM0 LM1>;
+            key-positions = <LT0 LM1>;
             layers = <DEFAULT NUM_NAV>;
         };
 
         close_curly {
             bindings = <&kp RIGHT_BRACE>;
-            key-positions = <RM0 RM1>;
+            key-positions = <RT0 RM1>;
             layers = <DEFAULT NUM_NAV>;
         };
 #endif
 
         // 2-key horizontal combos for () with shift for <>
-#ifndef LT0
-        open_bracket_less_than {
-            bindings = <&open_par_lt>;
-            key-positions = <LM1 LB0>;
-            layers = <DEFAULT NUM_NAV>;
-        };
-
-        close_bracket_greater_than {
-            bindings = <&close_par_gt>;
-            key-positions = <RM1 RB0>;
-            layers = <DEFAULT NUM_NAV>;
-        };
-#else
-        open_bracket_less_than {
+       open_bracket_less_than {
             bindings = <&open_par_lt>;
             key-positions = <LM0 LM1>;
             layers = <DEFAULT NUM_NAV>;
@@ -672,8 +631,21 @@
             key-positions = <RM0 RM1>;
             layers = <DEFAULT NUM_NAV>;
         };
-#endif
 
+#ifndef LB0
+        // 2-key horizontal combos for [] with shifted form {}
+        open_square_curly {
+            bindings = <AS(LEFT_BRACKET)>;
+            key-positions = <LM0 LB1>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+
+        close_square_curly {
+            bindings = <AS(RIGHT_BRACKET)>;
+            key-positions = <RM0 RB1>;
+            layers = <DEFAULT NUM_NAV>;
+        };
+#else
         // 2-key horizontal combos for [] with shifted form {}
         open_square_curly {
             bindings = <AS(LEFT_BRACKET)>;
@@ -686,6 +658,7 @@
             key-positions = <RB0 RB1>;
             layers = <DEFAULT NUM_NAV>;
         };
+#endif
 
 // Bluetooth combos for the Hesse
 #ifdef CONFIG_WIRELESS

--- a/config/bivouac34.keymap
+++ b/config/bivouac34.keymap
@@ -18,38 +18,38 @@ Using that here, see the chosen setting.
 
 #pragma once
 
-// Do NOT define LT0
-#define LT1  3  // left-top row
+#define LT0  4  // left-top row
+#define LT1  3
 #define LT2  2
 #define LT3  1
 #define LT4  0
 
-// Do NOT define RT0
-#define RT1  6  // right-top row
+#define RT0  5  // right-top row
+#define RT1  6
 #define RT2  7
 #define RT3  8
 #define RT4  9
 
-#define LM0 4  // left-middle row
+#define LM0 14 // left-middle row
 #define LM1 13
 #define LM2 12
 #define LM3 11
 #define LM4 10
 
-#define RM0 5  // right-middle row
+#define RM0 15 // right-middle row
 #define RM1 16
 #define RM2 17
 #define RM3 18
 #define RM4 19
 
-#define LB0 14  // left-bottom row
-#define LB1 23
+// Do NOT define LB0
+#define LB1 23  // left-bottom row
 #define LB2 22
 #define LB3 21
 #define LB4 20
 
-#define RB0 15  // right-bottom row
-#define RB1 24
+// Do NOT define RB0
+#define RB1 24  // right-bottom row
 #define RB2 25
 #define RB3 26
 #define RB4 27

--- a/config/bivvy16d.keymap
+++ b/config/bivvy16d.keymap
@@ -22,38 +22,38 @@ Same, just without LH0 and RH0 aka keys 40 and 41. That is used here (see the ch
 
 #pragma once
 
-// Do NOT define LT0
-#define LT1  3  // left-top row
+#define LT0  4  // left-top row
+#define LT1  3
 #define LT2  2
 #define LT3  1
 #define LT4  0
 
-// Do NOT define RT0
-#define RT1  6  // right-top row
+#define RT0  5  // right-top row
+#define RT1  6
 #define RT2  7
 #define RT3  8
 #define RT4  9
 
-#define LM0 4  // left-middle row
+#define LM0 14 // left-middle row
 #define LM1 13
 #define LM2 12
 #define LM3 11
 #define LM4 10
 
-#define RM0 5  // right-middle row
+#define RM0 15 // right-middle row
 #define RM1 16
 #define RM2 17
 #define RM3 18
 #define RM4 19
 
-#define LB0 14  // left-bottom row
-#define LB1 23
+// Do NOT define LB0
+#define LB1 23  // left-bottom row
 #define LB2 22
 #define LB3 21
 #define LB4 20
 
-#define RB0 15  // right-bottom row
-#define RB1 26
+// Do NOT define RB0
+#define RB1 26  // right-bottom row
 #define RB2 27
 #define RB3 28
 #define RB4 29

--- a/config/goldilocks32.keymap
+++ b/config/goldilocks32.keymap
@@ -11,7 +11,7 @@ The logical layout in the firmware is like this, where the more tucked thumb is 
                       ╰────┴────╯                                         ╰─────┴─────╯
 
 
-However, the inner row are treated as higher up (LT0, LM0, RT0, RM0):
+However, the inner row are treated as higher up (LT0, LM0, RT0, RM0) with thumb keys LH1 and RH1:
 
   ╭────────────────────────┬────────────────────────╮ ╭─────────────────────────┬─────────────────────────╮
   │  0   1   2   3   4     │      5   6   7   8   9 │ │ LT4 LT3 LT2 LT1 LT0     │     RT0 RT1 RT2 RT3 RT4 │
@@ -29,38 +29,38 @@ Same, just without LH0 and RH0 aka keys 35 and 36. That is used here (see the ch
 
 #pragma once
 
-// Do NOT define LT0
-#define LT1  3  // left-top row
+#define LT0  4  // left-top row
+#define LT1  3
 #define LT2  2
 #define LT3  1
 #define LT4  0
 
-// Do NOT define RT0
-#define RT1  6  // right-top row
+#define RT0  5  // right-top row
+#define RT1  6
 #define RT2  7
 #define RT3  8
 #define RT4  9
 
-#define LM0 4  // left-middle row
+#define LM0 14 // left-middle row
 #define LM1 13
 #define LM2 12
 #define LM3 11
 #define LM4 10
 
-#define RM0 5  // right-middle row
+#define RM0 15 // right-middle row
 #define RM1 16
 #define RM2 17
 #define RM3 18
 #define RM4 19
 
-#define LB0 14  // left-bottom row
-#define LB1 23
+// Do NOT define LB0
+#define LB1 23  // left-bottom row
 #define LB2 22
 #define LB3 21
 #define LB4 20
 
-#define RB0 15  // right-bottom row
-#define RB1 26
+// Do NOT define RB0
+#define RB1 26  // right-bottom row
 #define RB2 27
 #define RB3 28
 #define RB4 29

--- a/config/rugby_union.keymap
+++ b/config/rugby_union.keymap
@@ -14,38 +14,38 @@ as (LT0, LM0, RT0, RM0):
 
 #pragma once
 
-// Do NOT define LT0
-#define LT1  3  // left-top row
+#define LT0  4  // left-top row
+#define LT1  3
 #define LT2  2
 #define LT3  1
 #define LT4  0
 
-// Do NOT define RT0
-#define RT1  6  // right-top row
+#define RT0  5  // right-top row
+#define RT1  6
 #define RT2  7
 #define RT3  8
 #define RT4  9
 
-#define LM0 4  // left-middle row
+#define LM0 14 // left-middle row
 #define LM1 13
 #define LM2 12
 #define LM3 11
 #define LM4 10
 
-#define RM0 5  // right-middle row
+#define RM0 15 // right-middle row
 #define RM1 16
 #define RM2 17
 #define RM3 18
 #define RM4 19
 
-#define LB0 14  // left-bottom row
-#define LB1 23
+// Do NOT define LB0
+#define LB1 23  // left-bottom row
 #define LB2 22
 #define LB3 21
 #define LB4 20
 
-#define RB0 15  // right-bottom row
-#define RB1 26
+// Do NOT define RB0
+#define RB1 26  // right-bottom row
 #define RB2 27
 #define RB3 28
 #define RB4 29

--- a/config/slump52.keymap
+++ b/config/slump52.keymap
@@ -1,50 +1,50 @@
 /*                              35 core KEY MATRIX / LAYOUT MAPPING
 
   ╭────────────────────╮      ╭────────────────────╮ ╭─────────────────────╮      ╭─────────────────────╮
-  │  1   2   3   4   5 │      │  6   7   8   9  10 │ │ LN4 LT3 LT2 LT1 LM0 │      │ RM0 RT1 RT2 RT3 RN4 │
-  │ 15  16  17  18  19 │      │ 20  21  22  23  24 │ │ LT4 LM3 LM2 LM1 LB0 │      │ RB0 RM1 RM2 RM3 RT4 │
+  │  1   2   3   4   5 │      │  6   7   8   9  10 │ │ LN4 LT3 LT2 LT1 LT0 │      │ RT0 RT1 RT2 RT3 RN4 │
+  │ 15  16  17  18  19 │      │ 20  21  22  23  24 │ │ LT4 LM3 LM2 LM1 LM0 │      │ RM0 RM1 RM2 RM3 RT4 │
   │ 28  29  30  31  32 ╰──────╯ 33  34  35  36  37 │ │ LM4 LB3 LB2 LB1 LH2 ╰──────╯ RH2 RB1 RB2 RB3 RM4 │
   │ 41  ╭───────────╮ 42  43  44 ╭───────────╮  49 │ │ LB4 ╭────────────╮ LH1 RH0 RH1 ╭───────────╮ RB4 │
   ╰─────╯           ╰────────────╯           ╰─────╯ ╰─────╯            ╰─────────────╯           ╰─────╯
 
-Using pinky stagger here, and treating the thumbs as five thumb keys with no Qwerty T and Y (LT0 and RT0).
+Using pinky stagger here, and treating the thumbs as five thumb keys with no Qwerty B and N (LB0 and RB0).
 
 */
 
 #pragma once
 
-// Do NOT define LT0
-#define LT1  4  // left-top row
+#define LT0  5  // left-top row
+#define LT1  4
 #define LT2  3
 #define LT3  2
 #define LT4  15
 
-// Do NOT define RT0
-#define RT1  7  // right-top row
+#define RT0  6  // right-top row
+#define RT1  7
 #define RT2  8
 #define RT3  9
 #define RT4  24
 
-#define LM0 5  // left-middle row
+#define LM0 19  // left-middle row
 #define LM1 18
 #define LM2 17
 #define LM3 16
 #define LM4 28
 
-#define RM0 6  // right-middle row
+#define RM0 20  // right-middle row
 #define RM1 21
 #define RM2 22
 #define RM3 23
 #define RM4 37
 
-#define LB0 19  // left-bottom row
-#define LB1 31
+// Do NOT define LB0
+#define LB1 31  // left-bottom row
 #define LB2 30
 #define LB3 29
 #define LB4 41
 
-#define RB0 20  // right-bottom row
-#define RB1 34
+// Do NOT define RB0
+#define RB1 34  // right-bottom row
 #define RB2 35
 #define RB3 36
 #define RB4 49

--- a/keymap-drawer/bivouac34.svg
+++ b/keymap-drawer/bivouac34.svg
@@ -270,10 +270,10 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-1">
-<path d="M342,211 h-58 a6.0,6.0 0 0 1 -6.0,-6.0 v-56" class="combo"/>
-<path d="M342,211 h58 a6.0,6.0 0 0 0 6.0,-6.0 v-56" class="combo"/>
 <path d="M342,211 h-78 a6.0,6.0 0 0 1 -6.0,-6.0 v-4" class="combo"/>
 <path d="M342,211 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-4" class="combo"/>
+<path d="M342,211 h-58 a6.0,6.0 0 0 1 -6.0,-6.0 v-56" class="combo"/>
+<path d="M342,211 h58 a6.0,6.0 0 0 0 6.0,-6.0 v-56" class="combo"/>
 <rect rx="6" ry="6" x="317" y="198" width="50" height="26" class="combo"/>
 <text x="342" y="211" class="combo tap">
 <tspan x="342" dy="-0.6em">Boot</tspan><tspan x="342" dy="1.2em">loader</tspan>

--- a/keymap-drawer/bivouac34.yaml
+++ b/keymap-drawer/bivouac34.yaml
@@ -110,7 +110,7 @@ combos:
   a: top
   o: 0.3
   w: 50.0
-- p: [4, 5, 14, 15]
+- p: [14, 15, 4, 5]
   k: Boot loader
   l: [HD Promethium]
   a: bottom
@@ -216,7 +216,7 @@ combos:
 - p: [3, 13]
   k: $
   l: [HD Promethium, Num + Nav]
-- p: [3, 4]
+- p: [4, 3]
   k: \
   l: [HD Promethium, Num + Nav]
 - p: [4, 14]
@@ -248,10 +248,10 @@ combos:
 - p: [5, 16]
   k: '}'
   l: [HD Promethium, Num + Nav]
-- p: [13, 14]
+- p: [14, 13]
   k: (<
   l: [HD Promethium, Num + Nav]
-- p: [16, 15]
+- p: [15, 16]
   k: )>
   l: [HD Promethium, Num + Nav]
 - p: [14, 23]

--- a/keymap-drawer/bivvy16d.svg
+++ b/keymap-drawer/bivvy16d.svg
@@ -303,10 +303,10 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-1">
-<path d="M349,211 h-65 a6.0,6.0 0 0 1 -6.0,-6.0 v-56" class="combo"/>
-<path d="M349,211 h65 a6.0,6.0 0 0 0 6.0,-6.0 v-56" class="combo"/>
 <path d="M349,211 h-85 a6.0,6.0 0 0 1 -6.0,-6.0 v-4" class="combo"/>
 <path d="M349,211 h85 a6.0,6.0 0 0 0 6.0,-6.0 v-4" class="combo"/>
+<path d="M349,211 h-65 a6.0,6.0 0 0 1 -6.0,-6.0 v-56" class="combo"/>
+<path d="M349,211 h65 a6.0,6.0 0 0 0 6.0,-6.0 v-56" class="combo"/>
 <rect rx="6" ry="6" x="324" y="198" width="50" height="26" class="combo"/>
 <text x="349" y="211" class="combo tap">
 <tspan x="349" dy="-0.6em">Boot</tspan><tspan x="349" dy="1.2em">loader</tspan>

--- a/keymap-drawer/bivvy16d.yaml
+++ b/keymap-drawer/bivvy16d.yaml
@@ -134,7 +134,7 @@ combos:
   a: top
   o: 0.3
   w: 50.0
-- p: [4, 5, 14, 15]
+- p: [14, 15, 4, 5]
   k: Boot loader
   l: [HD Promethium]
   a: bottom
@@ -240,7 +240,7 @@ combos:
 - p: [3, 13]
   k: $
   l: [HD Promethium, Num + Nav]
-- p: [3, 4]
+- p: [4, 3]
   k: \
   l: [HD Promethium, Num + Nav]
 - p: [4, 14]
@@ -272,10 +272,10 @@ combos:
 - p: [5, 16]
   k: '}'
   l: [HD Promethium, Num + Nav]
-- p: [13, 14]
+- p: [14, 13]
   k: (<
   l: [HD Promethium, Num + Nav]
-- p: [16, 15]
+- p: [15, 16]
   k: )>
   l: [HD Promethium, Num + Nav]
 - p: [14, 23]

--- a/keymap-drawer/goldilocks32.svg
+++ b/keymap-drawer/goldilocks32.svg
@@ -281,10 +281,10 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-1">
-<path d="M341,218 h-59 a6.0,6.0 0 0 1 -6.0,-6.0 v-58" class="combo"/>
-<path d="M341,218 h59 a6.0,6.0 0 0 0 6.0,-6.0 v-58" class="combo"/>
 <path d="M341,218 h-78 a6.0,6.0 0 0 1 -6.0,-6.0 v-4" class="combo"/>
 <path d="M341,218 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-4" class="combo"/>
+<path d="M341,218 h-59 a6.0,6.0 0 0 1 -6.0,-6.0 v-58" class="combo"/>
+<path d="M341,218 h59 a6.0,6.0 0 0 0 6.0,-6.0 v-58" class="combo"/>
 <rect rx="6" ry="6" x="316" y="205" width="50" height="26" class="combo"/>
 <text x="341" y="218" class="combo tap">
 <tspan x="341" dy="-0.6em">Boot</tspan><tspan x="341" dy="1.2em">loader</tspan>

--- a/keymap-drawer/goldilocks32.yaml
+++ b/keymap-drawer/goldilocks32.yaml
@@ -119,7 +119,7 @@ combos:
   a: top
   o: 0.3
   w: 50.0
-- p: [4, 5, 14, 15]
+- p: [14, 15, 4, 5]
   k: Boot loader
   l: [HD Promethium]
   a: bottom
@@ -225,7 +225,7 @@ combos:
 - p: [3, 13]
   k: $
   l: [HD Promethium, Num + Nav]
-- p: [3, 4]
+- p: [4, 3]
   k: \
   l: [HD Promethium, Num + Nav]
 - p: [4, 14]
@@ -257,10 +257,10 @@ combos:
 - p: [5, 16]
   k: '}'
   l: [HD Promethium, Num + Nav]
-- p: [13, 14]
+- p: [14, 13]
   k: (<
   l: [HD Promethium, Num + Nav]
-- p: [16, 15]
+- p: [15, 16]
   k: )>
   l: [HD Promethium, Num + Nav]
 - p: [14, 23]

--- a/keymap-drawer/rugby_union.svg
+++ b/keymap-drawer/rugby_union.svg
@@ -261,10 +261,10 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-1">
-<path d="M365,278 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-44" class="combo"/>
-<path d="M365,278 h75 a6.0,6.0 0 0 0 6.0,-6.0 v-44" class="combo"/>
 <path d="M365,278 h-111 a6.0,6.0 0 0 1 -6.0,-6.0 v-4" class="combo"/>
 <path d="M365,278 h110 a6.0,6.0 0 0 0 6.0,-6.0 v-4" class="combo"/>
+<path d="M365,278 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-44" class="combo"/>
+<path d="M365,278 h75 a6.0,6.0 0 0 0 6.0,-6.0 v-44" class="combo"/>
 <rect rx="6" ry="6" x="340" y="265" width="50" height="26" class="combo"/>
 <text x="365" y="278" class="combo tap">
 <tspan x="365" dy="-0.6em">Boot</tspan><tspan x="365" dy="1.2em">loader</tspan>

--- a/keymap-drawer/rugby_union.yaml
+++ b/keymap-drawer/rugby_union.yaml
@@ -104,7 +104,7 @@ combos:
   a: top
   o: 0.3
   w: 50.0
-- p: [4, 5, 14, 15]
+- p: [14, 15, 4, 5]
   k: Boot loader
   l: [HD Promethium]
   a: bottom
@@ -210,7 +210,7 @@ combos:
 - p: [3, 13]
   k: $
   l: [HD Promethium, Num + Nav]
-- p: [3, 4]
+- p: [4, 3]
   k: \
   l: [HD Promethium, Num + Nav]
 - p: [4, 14]
@@ -242,10 +242,10 @@ combos:
 - p: [5, 16]
   k: '}'
   l: [HD Promethium, Num + Nav]
-- p: [13, 14]
+- p: [14, 13]
   k: (<
   l: [HD Promethium, Num + Nav]
-- p: [16, 15]
+- p: [15, 16]
   k: )>
   l: [HD Promethium, Num + Nav]
 - p: [14, 23]

--- a/keymap-drawer/slump52.svg
+++ b/keymap-drawer/slump52.svg
@@ -352,10 +352,10 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-1">
-<path d="M347,206 h-46 a6.0,6.0 0 0 1 -6.0,-6.0 v-55" class="combo"/>
-<path d="M347,206 h46 a6.0,6.0 0 0 0 6.0,-6.0 v-55" class="combo"/>
 <path d="M347,206 h-69 a6.0,6.0 0 0 1 -6.0,-6.0 v-4" class="combo"/>
 <path d="M347,206 h69 a6.0,6.0 0 0 0 6.0,-6.0 v-4" class="combo"/>
+<path d="M347,206 h-46 a6.0,6.0 0 0 1 -6.0,-6.0 v-55" class="combo"/>
+<path d="M347,206 h46 a6.0,6.0 0 0 0 6.0,-6.0 v-55" class="combo"/>
 <rect rx="6" ry="6" x="322" y="193" width="50" height="26" class="combo"/>
 <text x="347" y="206" class="combo tap">
 <tspan x="347" dy="-0.6em">Boot</tspan><tspan x="347" dy="1.2em">loader</tspan>

--- a/keymap-drawer/slump52.yaml
+++ b/keymap-drawer/slump52.yaml
@@ -170,7 +170,7 @@ combos:
   a: top
   o: 0.3
   w: 50.0
-- p: [5, 6, 19, 20]
+- p: [19, 20, 5, 6]
   k: Boot loader
   l: [HD Promethium]
   a: bottom
@@ -276,7 +276,7 @@ combos:
 - p: [4, 18]
   k: $
   l: [HD Promethium, Num + Nav]
-- p: [4, 5]
+- p: [5, 4]
   k: \
   l: [HD Promethium, Num + Nav]
 - p: [5, 19]
@@ -308,10 +308,10 @@ combos:
 - p: [6, 21]
   k: '}'
   l: [HD Promethium, Num + Nav]
-- p: [18, 19]
+- p: [19, 18]
   k: (<
   l: [HD Promethium, Num + Nav]
-- p: [21, 20]
+- p: [20, 21]
   k: )>
   l: [HD Promethium, Num + Nav]
 - p: [19, 31]


### PR DESCRIPTION
Previously defined by dropping the top pair LT0/RT0 (Qwerty T and Y).

Now defined by dropping the bottom pair LB0/RB0 (Qwerty B and N), in line with my default firmware and today's inner column changes in #38 and #39.

Essentially the 2-key inner column is now middle and top row, was middle and bottom row (in order to prefer K/J on the left inner column for vim style up/down).