### PR TITLE
Move auto-shift to separate layer with toggle combo

### DIFF
--- a/config/3x5_3.dtsi
+++ b/config/3x5_3.dtsi
@@ -30,8 +30,9 @@
 
 // Aliases for my layers
 #define DEFAULT 0
-#define NAGINATA 1
-#define NUM_NAV 2
+#define AS_LAYER 1
+#define NAGINATA 2
+#define NUM_NAV 3
 
 #define my_linger_term 300// linger mod-tap trigger time window
 
@@ -288,6 +289,16 @@
         default_layer {
             display-name = "HD Promethium";
             bindings = <LAYER_FROM36( \
+                &kp ESCAPE, &kp P, &kp G, &kp M, &kp K,      &dot_colon,  &kp BSPC, &xquote, AS(MINUS), AS(EQUAL), \
+                &kp S,      &kp N, &kp T, &kp H, &kp J,      &comma_semi, &kp A,    &kp E,   &kp I,     &kp C, \
+                &kp B,      &kp F, &kp D, &kp L, &kp LEFT,   &kp RIGHT,   &kp U,    &kp O,   &kp Y,     &kp W, \
+                &kp TAB, &bmt LSHFT R, &hpmt LSHFT BSPC,     &kp RSHFT, &space_R_layer NUM_NAV 0, &mo NUM_NAV \
+            )>;
+        };
+
+        auto_shift_layer {
+            display-name = "HD Promethium (AS)";
+            bindings = <LAYER_FROM36( \
                 &kp ESCAPE, AS(P), AS(G), AS(M), AS(K),      &dot_colon,  AS(BSPC), &xquote, AS(MINUS), AS(EQUAL), \
                 AS(S),      AS(N), AS(T), AS(H), AS(J),      &comma_semi, AS(A),    AS(E),   AS(I),     AS(C),  \
                 AS(B),      AS(F), AS(D), AS(L), &kp LEFT,   &kp RIGHT,   AS(U),    AS(O),   AS(Y),     AS(W),  \
@@ -364,6 +375,14 @@
         };
 #endif
 
+        // Combo on numbers/nav layer to toggle auto-shift on/off
+        combo_toggle_as {
+            timeout-ms = <300>;
+            key-positions = <LT0 RT0>;
+            bindings = <&tog AS_LAYER>;
+            layers = <NUM_NAV>;
+        };
+
         // Japanese mode and 薙刀 (Naginata Style) on/off
         // Can't use <RM0 RM1> Qwerty H+J as I use that for close bracket
         combo_ng_on {
@@ -371,7 +390,7 @@
             require-prior-idle-ms = <250>;
             key-positions = <RM1 RM3>; // Qwerty J+L, on right hand home row
             bindings = <&ng_on>;
-            layers = <DEFAULT NAGINATA>;
+            layers = <DEFAULT AS_LAYER NAGINATA>;
         };
         // Can't use <LM0 LM1> Qwerty F+G as I use that for open bracket
         combo_ng_off {
@@ -379,7 +398,7 @@
             require-prior-idle-ms = <250>;
             key-positions = <LM1 LM3>; // Qwerty S+F, on left hand home row
             bindings = <&ng_off>;
-            layers = <DEFAULT NAGINATA>;
+            layers = <DEFAULT AS_LAYER NAGINATA>;
         };
 
         // 3-key horizontal combos on bottom row
@@ -401,38 +420,38 @@
         left_alt_combo {
             bindings = <&kp LALT>;
             key-positions = <LM3 LM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
         };
         right_alt_combo {
             bindings = <&kp RALT>;
             key-positions = <RM3 RM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
         };
         left_ctrl_combo {
             bindings = <&kp LCTRL>;
             key-positions = <LM2 LM3>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
         };
         right_ctrl_combo {
             bindings = <&kp RCTRL>;
             key-positions = <RM2 RM3>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <200>;
         };
         left_gui_combo {
             bindings = <&kp LGUI>;
             key-positions = <LM1 LM2>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <200>;
             timeout-ms = <40>;
         };
         right_gui_combo {
             bindings = <&kp RGUI>;
             key-positions = <RM1 RM2>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <200>;
             timeout-ms = <40>;
         };
@@ -440,42 +459,42 @@
         left_ctrl_gui_combo {
             bindings = <&kp LC(LGUI)>;
             key-positions = <LM1 LM2 LM3>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
         right_ctrl_gui_combo {
             bindings = <&kp RC(RGUI)>;
             key-positions = <RM1 RM2 RM3>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
         left_ctrl_alt_combo {
             bindings = <&kp LC(LALT)>;
             key-positions = <LM2 LM3 LM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
         right_ctrl_alt_combo {
             bindings = <&kp RC(RALT)>;
             key-positions = <RM2 RM3 RM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
         left_ctrl_alt_gui_combo {
             bindings = <&kp LC(LA(LGUI))>;
             key-positions = <LM1 LM2 LM3 LM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
         right_ctrl_alt_gui_combo {
             bindings = <&kp RC(RA(RGUI))>;
             key-positions = <RM1 RM2 RM3 RM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
@@ -484,14 +503,14 @@
         left_shift_combo {
             bindings = <&kp LSHFT>;
             key-positions = <LB1 LB2>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
         right_shift_combo {
             bindings = <&kp RSHFT>;
             key-positions = <RB1 RB2>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
             require-prior-idle-ms = <250>;
             timeout-ms = <40>;
         };
@@ -500,28 +519,28 @@
         q_combo {
             bindings = <AS(Q)>;
             key-positions = <LT1 LT2>;
-            layers = <DEFAULT>;
+            layers = <DEFAULT AS_LAYER>;
             timeout-ms = <100>;
         };
 
         z_combo {
             bindings = <AS(Z)>;
             key-positions = <RT2 RT3>;
-            layers = <DEFAULT>;
+            layers = <DEFAULT AS_LAYER>;
             timeout-ms = <75>;
         };
 
         v_combo {
             bindings = <AS(V)>;
             key-positions = <LT2 LT3>;
-            layers = <DEFAULT>;
+            layers = <DEFAULT AS_LAYER>;
             timeout-ms = <75>;
         };
 
         x_combo {
             bindings = <AS(X)>;
             key-positions = <LB2 LB3>;
-            layers = <DEFAULT>;
+            layers = <DEFAULT AS_LAYER>;
             timeout-ms = <75>;
         };
 
@@ -529,7 +548,7 @@
         caps_word_combo {
             bindings = <&caps_word>;
             key-positions = <LH1 RH1>;
-            layers = <DEFAULT>;
+            layers = <DEFAULT AS_LAYER>;
             timeout-ms = <75>;
         };
 
@@ -545,73 +564,73 @@
         backtick {
             bindings = <&kp GRAVE>;
             key-positions = <LT4 LM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         at_sign {
             bindings = <&kp LS(SQT)>;
             key-positions = <LT3 LM3>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         pipe_sign {
             bindings = <&kp LS(NON_US_BACKSLASH)>;
             key-positions = <LT2 LM2>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         dollar_sign {
             bindings = <&kp DOLLAR>;
             key-positions = <LT1 LM1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
        backslash_sign {
             bindings = <&kp NON_US_BACKSLASH>;
             key-positions = <LT0 LT1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         percent_sign {
             bindings = <&kp PERCENT>;
             key-positions = <LT0 LM0>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
        slash_sign {
             bindings = <&kp SLASH>;
             key-positions = <RT1 RT0>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         caret_sign {
             bindings = <&kp CARET>;
             key-positions = <RT0 RM0>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         question_mark {
             bindings = <&kp QMARK>;
             key-positions = <RT1 RM1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         hash_sign {
             bindings = <&kp NON_US_HASH>;
             key-positions = <RT2 RM2>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         exclamation_mark {
             bindings = <&kp EXCLAMATION>;
             key-positions = <RT3 RM3>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         tilde_sign {
             bindings = <&kp LS(NON_US_HASH)>;
             key-positions = <RT4 RM4>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         // 2-key horizontal combos for {}, can instead use shift with the [] combos:
@@ -620,13 +639,13 @@
         open_curly {
             bindings = <&kp LEFT_BRACE>;
             key-positions = <LT0 LM1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         close_curly {
             bindings = <&kp RIGHT_BRACE>;
             key-positions = <RT0 RM1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 #endif
 
@@ -634,13 +653,13 @@
        open_bracket_less_than {
             bindings = <&open_par_lt>;
             key-positions = <LM0 LM1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         close_bracket_greater_than {
             bindings = <&close_par_gt>;
             key-positions = <RM0 RM1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
 #ifndef LB0
@@ -648,26 +667,26 @@
         open_square_curly {
             bindings = <AS(LEFT_BRACKET)>;
             key-positions = <LM0 LB1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         close_square_curly {
             bindings = <AS(RIGHT_BRACKET)>;
             key-positions = <RM0 RB1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 #else
         // 2-key horizontal combos for [] with shifted form {}
         open_square_curly {
             bindings = <AS(LEFT_BRACKET)>;
             key-positions = <LB0 LB1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 
         close_square_curly {
             bindings = <AS(RIGHT_BRACKET)>;
             key-positions = <RB0 RB1>;
-            layers = <DEFAULT NUM_NAV>;
+            layers = <DEFAULT AS_LAYER NUM_NAV>;
         };
 #endif
 

--- a/keymap-drawer/acid.svg
+++ b/keymap-drawer/acid.svg
@@ -1,4 +1,4 @@
-<svg width="760" height="1109" viewBox="0 0 760 1109" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="760" height="1460" viewBox="0 0 760 1460" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(504, 38)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(560, 28)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -437,7 +436,300 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 351)" class="layer-Naginata">
+<g transform="translate(30, 351)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 62)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(84, 44)" class="key medium-low keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(140, 28)" class="key medium keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(196, 38)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(252, 44)" class="key low keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(448, 44)" class="key medium-low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(504, 38)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(560, 28)" class="key medium-low keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(616, 44)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(672, 62)" class="key low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(28, 118)" class="key high keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(84, 100)" class="key high keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(140, 84)" class="key high keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(196, 94)" class="key high keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(252, 100)" class="key low keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(448, 100)" class="key medium-low keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(504, 94)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(560, 84)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(616, 100)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(672, 118)" class="key medium keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(28, 174)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(84, 156)" class="key medium keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(140, 140)" class="key medium-high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(196, 150)" class="key medium-high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(252, 156)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">←</text>
+</g>
+<g transform="translate(448, 156)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">→</text>
+</g>
+<g transform="translate(504, 150)" class="key medium-high keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(560, 140)" class="key high keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(616, 156)" class="key medium keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(672, 174)" class="key medium keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g transform="translate(252, 224) rotate(25.0)" class="key high keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(298, 258) rotate(25.0)" class="key keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">⇧</text>
+</g>
+<g transform="translate(402, 258) rotate(-25.0)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⇧</text>
+</g>
+<g transform="translate(448, 224) rotate(-25.0)" class="key high keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g class="combo combopos-0">
+<path d="M588,128 h-78 a6.0,6.0 0 0 1 -6.0,-6.0 v-9" class="combo"/>
+<path d="M588,128 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<rect rx="6" ry="6" x="574" y="120" width="28" height="15" class="combo"/>
+<text x="588" y="128" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M112,128 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-9" class="combo"/>
+<path d="M112,128 h-22 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<rect rx="6" ry="6" x="98" y="120" width="28" height="15" class="combo"/>
+<text x="112" y="128" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M112,184 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-9" class="combo"/>
+<path d="M112,184 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-19" class="combo"/>
+<path d="M112,184 h-22 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<rect rx="6" ry="6" x="98" y="176" width="28" height="15" class="combo"/>
+<text x="112" y="184" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M532,184 h-22 a6.0,6.0 0 0 1 -6.0,-6.0 v-9" class="combo"/>
+<path d="M532,184 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-19" class="combo"/>
+<path d="M532,184 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<rect rx="6" ry="6" x="518" y="176" width="28" height="15" class="combo"/>
+<text x="532" y="184" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="42" y="96" width="28" height="26" class="combo"/>
+<text x="56" y="109" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="630" y="96" width="28" height="26" class="combo"/>
+<text x="644" y="109" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
+<text x="112" y="92" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="574" y="79" width="28" height="26" class="combo"/>
+<text x="588" y="92" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
+<text x="168" y="89" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
+<text x="532" y="89" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
+<text x="168" y="145" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
+<text x="532" y="145" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo low"/>
+<text x="168" y="33" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo low"/>
+<text x="588" y="36" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo low"/>
+<text x="112" y="36" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="98" y="135" width="28" height="26" class="combo low"/>
+<text x="112" y="148" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<path d="M350,224 l-79,0" class="combo"/>
+<path d="M350,224 l79,0" class="combo"/>
+<rect rx="6" ry="6" x="336" y="211" width="28" height="26" class="combo"/>
+<text x="350" y="224" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
+<text x="28" y="90" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
+<text x="84" y="72" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
+<text x="140" y="56" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
+<text x="196" y="66" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
+<text x="224" y="41" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M281,72 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M281,72 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
+<rect rx="6" ry="6" x="267" y="59" width="28" height="26" class="combo"/>
+<text x="281" y="72" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
+<text x="476" y="41" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M419,72 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M419,72 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
+<rect rx="6" ry="6" x="405" y="59" width="28" height="26" class="combo"/>
+<text x="419" y="72" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
+<text x="504" y="66" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
+<text x="560" y="56" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
+<text x="616" y="72" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
+<text x="672" y="90" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
+<text x="224" y="97" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
+<text x="476" y="97" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
+<text x="224" y="153" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
+<text x="476" y="153" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 702)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 62)" class="key keypos-0">
@@ -642,7 +934,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 702)" class="layer-Num + Nav">
+<g transform="translate(30, 1053)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 62)" class="key keypos-0">
@@ -787,141 +1079,150 @@ text.right {
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g class="combo combopos-0">
+<path d="M350,44 l-79,0" class="combo"/>
+<path d="M350,44 l79,0" class="combo"/>
+<rect rx="6" ry="6" x="336" y="31" width="28" height="26" class="combo"/>
+<text x="350" y="44" class="combo tap">
+<tspan x="350" dy="-0.6em">HD</tspan><tspan x="350" dy="1.2em">…</tspan>
+</text>
+<text x="350" y="55" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M112,184 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-9" class="combo"/>
 <path d="M112,184 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-19" class="combo"/>
 <path d="M112,184 h-22 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <rect rx="6" ry="6" x="98" y="176" width="28" height="15" class="combo"/>
 <text x="112" y="184" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M532,184 h-22 a6.0,6.0 0 0 1 -6.0,-6.0 v-9" class="combo"/>
 <path d="M532,184 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-19" class="combo"/>
 <path d="M532,184 h78 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <rect rx="6" ry="6" x="518" y="176" width="28" height="15" class="combo"/>
 <text x="532" y="184" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="42" y="96" width="28" height="26" class="combo"/>
 <text x="56" y="109" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="630" y="96" width="28" height="26" class="combo"/>
 <text x="644" y="109" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="98" y="79" width="28" height="26" class="combo"/>
 <text x="112" y="92" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="574" y="79" width="28" height="26" class="combo"/>
 <text x="588" y="92" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="154" y="76" width="28" height="26" class="combo"/>
 <text x="168" y="89" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="518" y="76" width="28" height="26" class="combo"/>
 <text x="532" y="89" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="154" y="132" width="28" height="26" class="combo"/>
 <text x="168" y="145" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="518" y="132" width="28" height="26" class="combo"/>
 <text x="532" y="145" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="14" y="77" width="28" height="26" class="combo"/>
 <text x="28" y="90" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="70" y="59" width="28" height="26" class="combo"/>
 <text x="84" y="72" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="126" y="43" width="28" height="26" class="combo"/>
 <text x="140" y="56" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="182" y="53" width="28" height="26" class="combo"/>
 <text x="196" y="66" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="210" y="28" width="28" height="26" class="combo"/>
 <text x="224" y="41" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M281,72 v-22 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M281,72 v22 a6.0,6.0 0 0 1 -6.0,6.0 h-4" class="combo"/>
 <rect rx="6" ry="6" x="267" y="59" width="28" height="26" class="combo"/>
 <text x="281" y="72" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="462" y="28" width="28" height="26" class="combo"/>
 <text x="476" y="41" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M419,72 v-22 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M419,72 v22 a6.0,6.0 0 0 0 6.0,6.0 h4" class="combo"/>
 <rect rx="6" ry="6" x="405" y="59" width="28" height="26" class="combo"/>
 <text x="419" y="72" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="490" y="53" width="28" height="26" class="combo"/>
 <text x="504" y="66" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="546" y="43" width="28" height="26" class="combo"/>
 <text x="560" y="56" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="602" y="59" width="28" height="26" class="combo"/>
 <text x="616" y="72" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="658" y="77" width="28" height="26" class="combo"/>
 <text x="672" y="90" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="210" y="84" width="28" height="26" class="combo"/>
 <text x="224" y="97" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="462" y="84" width="28" height="26" class="combo"/>
 <text x="476" y="97" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="210" y="140" width="28" height="26" class="combo"/>
 <text x="224" y="153" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="462" y="140" width="28" height="26" class="combo"/>
 <text x="476" y="153" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="42" y="40" width="28" height="26" class="combo"/>
 <text x="56" y="53" class="combo tap">BT</text>
 <text x="56" y="64" class="combo hold">0</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="98" y="23" width="28" height="26" class="combo"/>
 <text x="112" y="36" class="combo tap">BT</text>
 <text x="112" y="47" class="combo hold">1</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="154" y="20" width="28" height="26" class="combo"/>
 <text x="168" y="33" class="combo tap">BT</text>
 <text x="168" y="44" class="combo hold">2</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="518" y="20" width="28" height="26" class="combo"/>
 <text x="532" y="33" class="combo tap">
 <tspan x="532" dy="-0.6em">BT</tspan><tspan x="532" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="574" y="23" width="28" height="26" class="combo"/>
 <text x="588" y="36" class="combo tap">
 <tspan x="588" dy="-0.6em">BT</tspan><tspan x="588" dy="1.2em">…</tspan>

--- a/keymap-drawer/acid.yaml
+++ b/keymap-drawer/acid.yaml
@@ -7,6 +7,41 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: sS, type: high}
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: cC, type: medium}
+  - {t: bB, type: medium-low}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - ←
+  - →
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: wW, type: medium}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⌫, h: ⇧}
+  - ⇧
+  - {t: ⎵R, h: Num+Nav, type: high}
+  HD Promethium (AS):
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -121,16 +156,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [4, 5]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [16, 18]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [13, 11]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -149,120 +187,120 @@ combos:
   h: 15.0
 - p: [11, 10]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 19]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [12, 11]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 18]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [16, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12, 11]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [12, 11, 10]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 18, 19]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [13, 12, 11, 10]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18, 19]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [23, 22]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [26, 27]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 2]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [7, 8]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [2, 1]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [22, 21]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [30, 33]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [30, 33]
   k: ⇪
   l: [Naginata]
 - p: [0, 10]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 11]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 12]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 13]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 14]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [6, 5]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 15]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [6, 16]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [7, 17]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 18]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 19]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 13]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 16]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [24, 23]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [25, 26]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 0]
   k: {t: BT, h: '0'}
   l: [Num + Nav]

--- a/keymap-drawer/bivouac34.svg
+++ b/keymap-drawer/bivouac34.svg
@@ -1,4 +1,4 @@
-<svg width="743" height="1240" viewBox="0 0 743 1240" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="743" height="1634" viewBox="0 0 743 1634" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(449, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(501, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -437,7 +436,300 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 397)" class="layer-Naginata">
+<g transform="translate(30, 397)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(46, 56) rotate(10.0)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(106, 38) rotate(10.0)" class="key medium-low keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(183, 35) rotate(18.0)" class="key medium keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(235, 82) rotate(22.0)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(277, 130) rotate(22.0)" class="key low keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(406, 130) rotate(-22.0)" class="key medium-low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(449, 82) rotate(-22.0)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(501, 35) rotate(-18.0)" class="key medium-low keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(577, 38) rotate(-10.0)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(637, 56) rotate(-10.0)" class="key low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(28, 128)" class="key high keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(258, 182) rotate(22.0)" class="key low keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(426, 182) rotate(-22.0)" class="key medium-low keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(468, 134) rotate(-22.0)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(517, 88) rotate(-18.0)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(586, 93) rotate(-10.0)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(655, 128)" class="key medium keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(28, 184)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(488, 186) rotate(-22.0)" class="key medium-high keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(534, 142) rotate(-18.0)" class="key high keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(595, 148) rotate(-10.0)" class="key medium keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(655, 184)" class="key medium keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g transform="translate(200, 267) rotate(33.0)" class="key high keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(247, 299) rotate(33.0)" class="key keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">⇧</text>
+</g>
+<g transform="translate(436, 299) rotate(-33.0)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⇧</text>
+</g>
+<g transform="translate(483, 267) rotate(-33.0)" class="key high keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g class="combo combopos-0">
+<path d="M557,162 h-83 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M557,162 h24 a6.0,6.0 0 0 0 6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="543" y="155" width="28" height="15" class="combo"/>
+<text x="557" y="162" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M127,162 h82 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M127,162 h-23 a6.0,6.0 0 0 1 -6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="113" y="155" width="28" height="15" class="combo"/>
+<text x="127" y="162" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
+<text x="169" y="214" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M568,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M568,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M568,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="554" y="207" width="28" height="15" class="combo"/>
+<text x="568" y="214" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
+<text x="63" y="110" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="607" y="97" width="28" height="26" class="combo"/>
+<text x="621" y="110" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="538" y="78" width="28" height="26" class="combo"/>
+<text x="552" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="479" y="98" width="28" height="26" class="combo"/>
+<text x="493" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="497" y="151" width="28" height="26" class="combo"/>
+<text x="511" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="525" y="24" width="28" height="26" class="combo low"/>
+<text x="539" y="37" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
+<text x="144" y="37" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
+<text x="119" y="145" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<path d="M342,267 l-123,0" class="combo"/>
+<path d="M342,267 l123,0" class="combo"/>
+<rect rx="6" ry="6" x="328" y="254" width="28" height="26" class="combo"/>
+<text x="342" y="267" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
+<text x="37" y="92" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
+<text x="102" y="66" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
+<text x="174" y="62" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
+<text x="225" y="108" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
+<text x="256" y="106" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
+<rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
+<text x="306" y="156" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="413" y="93" width="28" height="26" class="combo"/>
+<text x="427" y="106" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M377,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M377,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
+<rect rx="6" ry="6" x="363" y="143" width="28" height="26" class="combo"/>
+<text x="377" y="156" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="444" y="95" width="28" height="26" class="combo"/>
+<text x="458" y="108" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="495" y="49" width="28" height="26" class="combo"/>
+<text x="509" y="62" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="568" y="53" width="28" height="26" class="combo"/>
+<text x="582" y="66" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="632" y="79" width="28" height="26" class="combo"/>
+<text x="646" y="92" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
+<text x="246" y="132" class="combo tap">{</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="423" y="119" width="28" height="26" class="combo"/>
+<text x="437" y="132" class="combo tap">}</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
+<text x="236" y="158" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="433" y="145" width="28" height="26" class="combo"/>
+<text x="447" y="158" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-39">
+<rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
+<text x="227" y="184" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-40">
+<rect rx="6" ry="6" x="443" y="171" width="28" height="26" class="combo"/>
+<text x="457" y="184" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 790)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 56) rotate(10.0)" class="key keypos-0">
@@ -634,7 +926,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 790)" class="layer-Num + Nav">
+<g transform="translate(30, 1184)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 56) rotate(10.0)" class="key keypos-0">
@@ -771,124 +1063,133 @@ text.right {
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g class="combo combopos-0">
+<path d="M342,130 l-46,0" class="combo"/>
+<path d="M342,130 l46,0" class="combo"/>
+<rect rx="6" ry="6" x="328" y="117" width="28" height="26" class="combo"/>
+<text x="342" y="130" class="combo tap">
+<tspan x="342" dy="-0.6em">HD</tspan><tspan x="342" dy="1.2em">…</tspan>
+</text>
+<text x="342" y="141" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
 <text x="169" y="214" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M568,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M568,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M568,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="554" y="207" width="28" height="15" class="combo"/>
 <text x="568" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
 <text x="63" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="607" y="97" width="28" height="26" class="combo"/>
 <text x="621" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
 <text x="132" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="538" y="78" width="28" height="26" class="combo"/>
 <text x="552" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
 <text x="190" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="479" y="98" width="28" height="26" class="combo"/>
 <text x="493" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="497" y="151" width="28" height="26" class="combo"/>
 <text x="511" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="413" y="93" width="28" height="26" class="combo"/>
 <text x="427" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M377,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M377,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="363" y="143" width="28" height="26" class="combo"/>
 <text x="377" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="444" y="95" width="28" height="26" class="combo"/>
 <text x="458" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="495" y="49" width="28" height="26" class="combo"/>
 <text x="509" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="568" y="53" width="28" height="26" class="combo"/>
 <text x="582" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="632" y="79" width="28" height="26" class="combo"/>
 <text x="646" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="423" y="119" width="28" height="26" class="combo"/>
 <text x="437" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="433" y="145" width="28" height="26" class="combo"/>
 <text x="447" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="443" y="171" width="28" height="26" class="combo"/>
 <text x="457" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivouac34.yaml
+++ b/keymap-drawer/bivouac34.yaml
@@ -7,6 +7,39 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: sS, type: high}
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: cC, type: medium}
+  - {t: bB, type: medium-low}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: wW, type: medium}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⌫, h: ⇧}
+  - ⇧
+  - {t: ⎵R, h: Num+Nav, type: high}
+  HD Promethium (AS):
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -115,16 +148,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [4, 5]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [16, 18]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [13, 11]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -143,123 +179,123 @@ combos:
   h: 15.0
 - p: [11, 10]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 19]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [12, 11]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 18]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [16, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12, 11]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [12, 11, 10]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 18, 19]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [13, 12, 11, 10]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18, 19]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [23, 22]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [24, 25]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 2]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [7, 8]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [2, 1]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [22, 21]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [28, 31]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [28, 31]
   k: ⇪
   l: [Naginata]
 - p: [0, 10]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 11]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 12]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 13]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 14]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [6, 5]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 15]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [6, 16]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [7, 17]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 18]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 19]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 13]
   k: '{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 16]
   k: '}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 13]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 16]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 23]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 24]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]

--- a/keymap-drawer/bivvy16d.svg
+++ b/keymap-drawer/bivvy16d.svg
@@ -1,4 +1,4 @@
-<svg width="757" height="1247" viewBox="0 0 757 1247" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="757" height="1643" viewBox="0 0 757 1643" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(463, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(515, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -470,7 +469,333 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 398)" class="layer-Naginata">
+<g transform="translate(30, 398)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(46, 56) rotate(10.0)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(106, 38) rotate(10.0)" class="key medium-low keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(183, 35) rotate(18.0)" class="key medium keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(235, 82) rotate(22.0)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(277, 130) rotate(22.0)" class="key low keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(420, 130) rotate(-22.0)" class="key medium-low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(463, 82) rotate(-22.0)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(515, 35) rotate(-18.0)" class="key medium-low keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(591, 38) rotate(-10.0)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(651, 56) rotate(-10.0)" class="key low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(28, 128)" class="key high keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(258, 182) rotate(22.0)" class="key low keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(440, 182) rotate(-22.0)" class="key medium-low keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(482, 134) rotate(-22.0)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(531, 88) rotate(-18.0)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(600, 93) rotate(-10.0)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(669, 128)" class="key medium keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(28, 184)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(245, 278) rotate(37.0)" class="key high keypos-24">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(453, 275) rotate(-37.0)" class="key high keypos-25">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g transform="translate(502, 186) rotate(-22.0)" class="key medium-high keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(548, 142) rotate(-18.0)" class="key high keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(609, 148) rotate(-10.0)" class="key medium keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(669, 184)" class="key medium keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g transform="translate(95, 315)" class="key keypos-30">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">⇟</text>
+</g>
+<g transform="translate(45, 265)" class="key keypos-31">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">↖</text>
+</g>
+<g transform="translate(95, 265)" class="key keypos-32">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">KP</tspan><tspan x="0" dy="1.2em">ENTER</tspan>
+</text>
+</g>
+<g transform="translate(146, 265)" class="key keypos-33">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">↘</text>
+</g>
+<g transform="translate(95, 214)" class="key keypos-34">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">⇞</text>
+</g>
+<g transform="translate(599, 214)" class="key keypos-35">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">↑</text>
+</g>
+<g transform="translate(549, 265)" class="key keypos-36">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">←</text>
+</g>
+<g transform="translate(599, 265)" class="key keypos-37">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">⏎</text>
+</g>
+<g transform="translate(650, 265)" class="key keypos-38">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">→</text>
+</g>
+<g transform="translate(599, 315)" class="key keypos-39">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">↓</text>
+</g>
+<g class="combo combopos-0">
+<path d="M571,162 h-83 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M571,162 h24 a6.0,6.0 0 0 0 6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="557" y="155" width="28" height="15" class="combo"/>
+<text x="571" y="162" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M127,162 h82 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M127,162 h-23 a6.0,6.0 0 0 1 -6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="113" y="155" width="28" height="15" class="combo"/>
+<text x="127" y="162" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
+<text x="169" y="214" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M582,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M582,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M582,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="568" y="207" width="28" height="15" class="combo"/>
+<text x="582" y="214" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
+<text x="63" y="110" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="621" y="97" width="28" height="26" class="combo"/>
+<text x="635" y="110" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="552" y="78" width="28" height="26" class="combo"/>
+<text x="566" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
+<text x="507" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
+<text x="525" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="539" y="24" width="28" height="26" class="combo low"/>
+<text x="553" y="37" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
+<text x="144" y="37" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
+<text x="119" y="145" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<path d="M349,276 l-72,1" class="combo"/>
+<path d="M349,276 l72,-1" class="combo"/>
+<rect rx="6" ry="6" x="335" y="263" width="28" height="26" class="combo"/>
+<text x="349" y="276" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
+<text x="37" y="92" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
+<text x="102" y="66" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
+<text x="174" y="62" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
+<text x="225" y="108" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
+<text x="256" y="106" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
+<rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
+<text x="306" y="156" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
+<text x="441" y="106" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
+<rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
+<text x="391" y="156" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
+<text x="472" y="108" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
+<text x="523" y="62" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
+<text x="596" y="66" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
+<text x="660" y="92" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
+<text x="246" y="132" class="combo tap">{</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
+<text x="451" y="132" class="combo tap">}</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
+<text x="236" y="158" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
+<text x="461" y="158" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-39">
+<rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
+<text x="227" y="184" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-40">
+<rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
+<text x="471" y="184" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 794)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 56) rotate(10.0)" class="key keypos-0">
@@ -700,7 +1025,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 794)" class="layer-Num + Nav">
+<g transform="translate(30, 1191)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 56) rotate(10.0)" class="key keypos-0">
@@ -871,124 +1196,133 @@ text.right {
 <text x="0" y="0" class="key tap">↓</text>
 </g>
 <g class="combo combopos-0">
+<path d="M349,130 l-53,0" class="combo"/>
+<path d="M349,130 l53,0" class="combo"/>
+<rect rx="6" ry="6" x="335" y="117" width="28" height="26" class="combo"/>
+<text x="349" y="130" class="combo tap">
+<tspan x="349" dy="-0.6em">HD</tspan><tspan x="349" dy="1.2em">…</tspan>
+</text>
+<text x="349" y="141" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
 <text x="169" y="214" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M582,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M582,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M582,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="568" y="207" width="28" height="15" class="combo"/>
 <text x="582" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="49" y="97" width="28" height="26" class="combo"/>
 <text x="63" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="621" y="97" width="28" height="26" class="combo"/>
 <text x="635" y="110" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
 <text x="132" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="552" y="78" width="28" height="26" class="combo"/>
 <text x="566" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
 <text x="190" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="493" y="98" width="28" height="26" class="combo"/>
 <text x="507" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="511" y="151" width="28" height="26" class="combo"/>
 <text x="525" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="23" y="79" width="28" height="26" class="combo"/>
 <text x="37" y="92" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="242" y="93" width="28" height="26" class="combo"/>
 <text x="256" y="106" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M306,156 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M306,156 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="292" y="143" width="28" height="26" class="combo"/>
 <text x="306" y="156" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="427" y="93" width="28" height="26" class="combo"/>
 <text x="441" y="106" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M391,156 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M391,156 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="377" y="143" width="28" height="26" class="combo"/>
 <text x="391" y="156" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="458" y="95" width="28" height="26" class="combo"/>
 <text x="472" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="509" y="49" width="28" height="26" class="combo"/>
 <text x="523" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="582" y="53" width="28" height="26" class="combo"/>
 <text x="596" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="646" y="79" width="28" height="26" class="combo"/>
 <text x="660" y="92" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="232" y="119" width="28" height="26" class="combo"/>
 <text x="246" y="132" class="combo tap">{</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="437" y="119" width="28" height="26" class="combo"/>
 <text x="451" y="132" class="combo tap">}</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="222" y="145" width="28" height="26" class="combo"/>
 <text x="236" y="158" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="447" y="145" width="28" height="26" class="combo"/>
 <text x="461" y="158" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="213" y="171" width="28" height="26" class="combo"/>
 <text x="227" y="184" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="457" y="171" width="28" height="26" class="combo"/>
 <text x="471" y="184" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/bivvy16d.yaml
+++ b/keymap-drawer/bivvy16d.yaml
@@ -7,6 +7,47 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: sS, type: high}
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: cC, type: medium}
+  - {t: bB, type: medium-low}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: wW, type: medium}
+  - ⇟
+  - ↖
+  - KP ENTER
+  - ↘
+  - ⇞
+  - ↑
+  - ←
+  - ⏎
+  - →
+  - ↓
+  HD Promethium (AS):
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -139,16 +180,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [4, 5]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [16, 18]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [13, 11]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -167,123 +211,123 @@ combos:
   h: 15.0
 - p: [11, 10]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 19]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [12, 11]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 18]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [16, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12, 11]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [12, 11, 10]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 18, 19]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [13, 12, 11, 10]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18, 19]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [23, 22]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [26, 27]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 2]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [7, 8]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [2, 1]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [22, 21]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [24, 25]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [24, 25]
   k: ⇪
   l: [Naginata]
 - p: [0, 10]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 11]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 12]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 13]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 14]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [6, 5]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 15]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [6, 16]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [7, 17]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 18]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 19]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 13]
   k: '{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 16]
   k: '}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 13]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 16]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 23]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 26]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]

--- a/keymap-drawer/goldilocks32.svg
+++ b/keymap-drawer/goldilocks32.svg
@@ -1,4 +1,4 @@
-<svg width="742" height="1227" viewBox="0 0 742 1227" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="742" height="1616" viewBox="0 0 742 1616" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(449, 85) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(501, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -446,7 +445,309 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 393)" class="layer-Naginata">
+<g transform="translate(30, 393)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(46, 65) rotate(10.0)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-37" width="52" height="74" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(106, 38) rotate(10.0)" class="key medium-low keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(181, 35) rotate(18.0)" class="key medium keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(234, 85) rotate(22.0)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(276, 136) rotate(22.0)" class="key low keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(406, 136) rotate(-22.0)" class="key medium-low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(449, 85) rotate(-22.0)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(501, 35) rotate(-18.0)" class="key medium-low keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(576, 38) rotate(-10.0)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(636, 65) rotate(-10.0)" class="key low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-37" width="52" height="74" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(28, 132)" class="key high keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(97, 95) rotate(10.0)" class="key high keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(166, 90) rotate(18.0)" class="key high keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(214, 139) rotate(22.0)" class="key high keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(257, 189) rotate(22.0)" class="key low keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(425, 189) rotate(-22.0)" class="key medium-low keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(468, 139) rotate(-22.0)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(516, 90) rotate(-18.0)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(585, 95) rotate(-10.0)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(654, 132)" class="key medium keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(28, 190)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(88, 152) rotate(10.0)" class="key medium keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(150, 145) rotate(18.0)" class="key medium-high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(195, 192) rotate(22.0)" class="key medium-high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(251, 274) rotate(37.0)" class="key high keypos-24">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(431, 274) rotate(-37.0)" class="key high keypos-25">
+<rect rx="6" ry="6" x="-46" y="-26" width="91" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g transform="translate(487, 192) rotate(-22.0)" class="key medium-high keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(533, 145) rotate(-18.0)" class="key high keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(594, 152) rotate(-10.0)" class="key medium keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(654, 190)" class="key medium keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g transform="translate(95, 207)" class="key keypos-30">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">↑</text>
+</g>
+<g transform="translate(45, 258)" class="key keypos-31">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">←</text>
+</g>
+<g transform="translate(95, 258)" class="key keypos-32">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">⏎</text>
+</g>
+<g transform="translate(146, 258)" class="key keypos-33">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">→</text>
+</g>
+<g transform="translate(95, 308)" class="key keypos-34">
+<rect rx="6" ry="6" x="-23" y="-23" width="46" height="46" class="key"/>
+<text x="0" y="0" class="key tap">↓</text>
+</g>
+<g class="combo combopos-0">
+<path d="M556,167 h-82 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M556,167 h23 a6.0,6.0 0 0 0 6.0,-6.0 v-47" class="combo"/>
+<rect rx="6" ry="6" x="542" y="159" width="28" height="15" class="combo"/>
+<text x="556" y="167" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M126,167 h82 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M126,167 h-23 a6.0,6.0 0 0 1 -6.0,-6.0 v-47" class="combo"/>
+<rect rx="6" ry="6" x="112" y="159" width="28" height="15" class="combo"/>
+<text x="126" y="167" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M169,220 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M169,220 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-50" class="combo"/>
+<path d="M169,220 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-43" class="combo"/>
+<rect rx="6" ry="6" x="155" y="213" width="28" height="15" class="combo"/>
+<text x="169" y="220" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M567,220 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M567,220 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-50" class="combo"/>
+<path d="M567,220 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-43" class="combo"/>
+<rect rx="6" ry="6" x="553" y="213" width="28" height="15" class="combo"/>
+<text x="567" y="220" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="48" y="101" width="28" height="26" class="combo"/>
+<text x="62" y="114" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="606" y="101" width="28" height="26" class="combo"/>
+<text x="620" y="114" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
+<text x="131" y="93" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="537" y="80" width="28" height="26" class="combo"/>
+<text x="551" y="93" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
+<text x="190" y="115" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="478" y="102" width="28" height="26" class="combo"/>
+<text x="492" y="115" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
+<text x="172" y="169" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="496" y="156" width="28" height="26" class="combo"/>
+<text x="510" y="169" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="193" y="47" width="28" height="26" class="combo low"/>
+<text x="207" y="60" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="524" y="24" width="28" height="26" class="combo low"/>
+<text x="538" y="37" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
+<text x="144" y="37" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="105" y="136" width="28" height="26" class="combo low"/>
+<text x="119" y="149" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<rect rx="6" ry="6" x="327" y="261" width="28" height="26" class="combo"/>
+<text x="341" y="274" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
+<text x="37" y="98" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
+<text x="101" y="67" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
+<text x="174" y="63" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
+<text x="224" y="112" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
+<text x="255" y="110" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
+<rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
+<text x="305" y="162" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="413" y="97" width="28" height="26" class="combo"/>
+<text x="427" y="110" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M377,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M377,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
+<rect rx="6" ry="6" x="363" y="149" width="28" height="26" class="combo"/>
+<text x="377" y="162" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="444" y="99" width="28" height="26" class="combo"/>
+<text x="458" y="112" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="494" y="50" width="28" height="26" class="combo"/>
+<text x="508" y="63" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="567" y="54" width="28" height="26" class="combo"/>
+<text x="581" y="67" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="631" y="85" width="28" height="26" class="combo"/>
+<text x="645" y="98" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
+<text x="245" y="137" class="combo tap">{</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="423" y="124" width="28" height="26" class="combo"/>
+<text x="437" y="137" class="combo tap">}</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
+<text x="236" y="164" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="432" y="151" width="28" height="26" class="combo"/>
+<text x="446" y="164" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-39">
+<rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
+<text x="226" y="191" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-40">
+<rect rx="6" ry="6" x="442" y="178" width="28" height="26" class="combo"/>
+<text x="456" y="191" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 782)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 65) rotate(10.0)" class="key keypos-0">
@@ -652,7 +953,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 782)" class="layer-Num + Nav">
+<g transform="translate(30, 1171)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(46, 65) rotate(10.0)" class="key keypos-0">
@@ -801,124 +1102,133 @@ text.right {
 <text x="0" y="0" class="key tap">↓</text>
 </g>
 <g class="combo combopos-0">
+<path d="M341,136 l-46,0" class="combo"/>
+<path d="M341,136 l46,0" class="combo"/>
+<rect rx="6" ry="6" x="327" y="123" width="28" height="26" class="combo"/>
+<text x="341" y="136" class="combo tap">
+<tspan x="341" dy="-0.6em">HD</tspan><tspan x="341" dy="1.2em">…</tspan>
+</text>
+<text x="341" y="147" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M169,220 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <path d="M169,220 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-50" class="combo"/>
 <path d="M169,220 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-43" class="combo"/>
 <rect rx="6" ry="6" x="155" y="213" width="28" height="15" class="combo"/>
 <text x="169" y="220" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M567,220 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M567,220 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-50" class="combo"/>
 <path d="M567,220 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-43" class="combo"/>
 <rect rx="6" ry="6" x="553" y="213" width="28" height="15" class="combo"/>
 <text x="567" y="220" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="48" y="101" width="28" height="26" class="combo"/>
 <text x="62" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="606" y="101" width="28" height="26" class="combo"/>
 <text x="620" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="117" y="80" width="28" height="26" class="combo"/>
 <text x="131" y="93" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="537" y="80" width="28" height="26" class="combo"/>
 <text x="551" y="93" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="176" y="102" width="28" height="26" class="combo"/>
 <text x="190" y="115" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="478" y="102" width="28" height="26" class="combo"/>
 <text x="492" y="115" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="158" y="156" width="28" height="26" class="combo"/>
 <text x="172" y="169" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="496" y="156" width="28" height="26" class="combo"/>
 <text x="510" y="169" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="23" y="85" width="28" height="26" class="combo"/>
 <text x="37" y="98" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="87" y="54" width="28" height="26" class="combo"/>
 <text x="101" y="67" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="160" y="50" width="28" height="26" class="combo"/>
 <text x="174" y="63" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="210" y="99" width="28" height="26" class="combo"/>
 <text x="224" y="112" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="241" y="97" width="28" height="26" class="combo"/>
 <text x="255" y="110" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M305,162 v-21 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M305,162 v21 a6.0,6.0 0 0 1 -6.0,6.0 h-23" class="combo"/>
 <rect rx="6" ry="6" x="291" y="149" width="28" height="26" class="combo"/>
 <text x="305" y="162" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="413" y="97" width="28" height="26" class="combo"/>
 <text x="427" y="110" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M377,162 v-21 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M377,162 v21 a6.0,6.0 0 0 0 6.0,6.0 h23" class="combo"/>
 <rect rx="6" ry="6" x="363" y="149" width="28" height="26" class="combo"/>
 <text x="377" y="162" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="444" y="99" width="28" height="26" class="combo"/>
 <text x="458" y="112" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="494" y="50" width="28" height="26" class="combo"/>
 <text x="508" y="63" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="567" y="54" width="28" height="26" class="combo"/>
 <text x="581" y="67" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="631" y="85" width="28" height="26" class="combo"/>
 <text x="645" y="98" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="231" y="124" width="28" height="26" class="combo"/>
 <text x="245" y="137" class="combo tap">{</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="423" y="124" width="28" height="26" class="combo"/>
 <text x="437" y="137" class="combo tap">}</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="222" y="151" width="28" height="26" class="combo"/>
 <text x="236" y="164" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="432" y="151" width="28" height="26" class="combo"/>
 <text x="446" y="164" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="212" y="178" width="28" height="26" class="combo"/>
 <text x="226" y="191" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="442" y="178" width="28" height="26" class="combo"/>
 <text x="456" y="191" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/goldilocks32.yaml
+++ b/keymap-drawer/goldilocks32.yaml
@@ -7,6 +7,42 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: sS, type: high}
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: cC, type: medium}
+  - {t: bB, type: medium-low}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: wW, type: medium}
+  - ↑
+  - ←
+  - ⏎
+  - →
+  - ↓
+  HD Promethium (AS):
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -124,16 +160,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [4, 5]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [16, 18]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [13, 11]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -152,123 +191,123 @@ combos:
   h: 15.0
 - p: [11, 10]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 19]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [12, 11]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 18]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [16, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12, 11]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [12, 11, 10]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 18, 19]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [13, 12, 11, 10]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18, 19]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [23, 22]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [26, 27]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 2]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [7, 8]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [2, 1]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [22, 21]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [24, 25]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [24, 25]
   k: ⇪
   l: [Naginata]
 - p: [0, 10]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 11]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 12]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 13]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 14]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [6, 5]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 15]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [6, 16]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [7, 17]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 18]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 19]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 13]
   k: '{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 16]
   k: '}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 13]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 16]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 23]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 26]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]

--- a/keymap-drawer/hesse.svg
+++ b/keymap-drawer/hesse.svg
@@ -1,4 +1,4 @@
-<svg width="780" height="1303" viewBox="0 0 780 1303" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="780" height="1718" viewBox="0 0 780 1718" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -448,7 +447,311 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 416)" class="layer-Naginata">
+<g transform="translate(30, 416)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 63)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(106, 38) rotate(10.0)" class="key medium-low keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(183, 35) rotate(18.0)" class="key medium keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(235, 82) rotate(22.0)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(282, 117) rotate(22.0)" class="key low keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(437, 117) rotate(-22.0)" class="key medium-low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(613, 38) rotate(-10.0)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(692, 63)" class="key low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(28, 119)" class="key high keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(262, 169) rotate(22.0)" class="key low keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(458, 169) rotate(-22.0)" class="key medium-low keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(505, 134) rotate(-22.0)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(554, 88) rotate(-18.0)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(622, 93) rotate(-10.0)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(692, 119)" class="key medium keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(28, 175)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(242, 221) rotate(22.0)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">←</text>
+</g>
+<g transform="translate(477, 221) rotate(-22.0)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">→</text>
+</g>
+<g transform="translate(524, 186) rotate(-22.0)" class="key medium-high keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(570, 142) rotate(-18.0)" class="key high keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(632, 148) rotate(-10.0)" class="key medium keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(692, 175)" class="key medium keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g transform="translate(143, 241) rotate(22.0)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">↹</text>
+</g>
+<g transform="translate(199, 274) rotate(37.0)" class="key high keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">⇧</text>
+</g>
+<g transform="translate(475, 320) rotate(-38.0)" class="key keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⇧</text>
+</g>
+<g transform="translate(521, 274) rotate(-37.0)" class="key high keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g transform="translate(576, 241) rotate(-22.0)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Num--Nav">
+<text x="0" y="0" class="key tap layer-activator">
+<tspan x="0" dy="-1.2em">Num</tspan><tspan x="0" dy="1.2em">+</tspan><tspan x="0" dy="1.2em">Nav</tspan>
+</text>
+</a></g>
+<g class="combo combopos-0">
+<path d="M593,162 h-82 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M593,162 h23 a6.0,6.0 0 0 0 6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="579" y="155" width="28" height="15" class="combo"/>
+<text x="593" y="162" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M127,162 h82 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M127,162 h-23 a6.0,6.0 0 0 1 -6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="113" y="155" width="28" height="15" class="combo"/>
+<text x="127" y="162" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
+<text x="169" y="214" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M605,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M605,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M605,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="591" y="207" width="28" height="15" class="combo"/>
+<text x="605" y="214" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
+<text x="63" y="106" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
+<text x="657" y="106" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
+<text x="588" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
+<text x="529" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
+<text x="547" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
+<text x="575" y="37" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
+<text x="144" y="37" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
+<text x="119" y="145" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<path d="M360,274 l-142,0" class="combo"/>
+<path d="M360,274 l142,0" class="combo"/>
+<rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
+<text x="360" y="274" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
+<text x="28" y="91" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
+<text x="102" y="66" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
+<text x="174" y="62" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
+<text x="225" y="108" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
+<text x="258" y="100" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M311,143 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M311,143 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
+<rect rx="6" ry="6" x="297" y="130" width="28" height="26" class="combo"/>
+<text x="311" y="143" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
+<text x="461" y="100" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M408,143 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M408,143 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
+<rect rx="6" ry="6" x="394" y="130" width="28" height="26" class="combo"/>
+<text x="408" y="143" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
+<text x="494" y="108" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
+<text x="545" y="62" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
+<text x="618" y="66" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
+<text x="692" y="91" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
+<text x="239" y="152" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
+<text x="481" y="152" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
+<text x="219" y="204" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
+<text x="501" y="204" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 831)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 63)" class="key keypos-0">
@@ -664,7 +967,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 831)" class="layer-Num + Nav">
+<g transform="translate(30, 1247)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 63)" class="key keypos-0">
@@ -816,141 +1119,150 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
 </g>
 <g class="combo combopos-0">
+<path d="M360,117 l-59,0" class="combo"/>
+<path d="M360,117 l59,0" class="combo"/>
+<rect rx="6" ry="6" x="346" y="104" width="28" height="26" class="combo"/>
+<text x="360" y="117" class="combo tap">
+<tspan x="360" dy="-0.6em">HD</tspan><tspan x="360" dy="1.2em">…</tspan>
+</text>
+<text x="360" y="128" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
 <text x="169" y="214" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M605,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M605,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M605,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="591" y="207" width="28" height="15" class="combo"/>
 <text x="605" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
 <text x="63" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
 <text x="657" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
 <text x="132" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
 <text x="588" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
 <text x="190" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
 <text x="547" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M311,143 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M311,143 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="297" y="130" width="28" height="26" class="combo"/>
 <text x="311" y="143" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M408,143 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M408,143 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="394" y="130" width="28" height="26" class="combo"/>
 <text x="408" y="143" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="53" y="37" width="28" height="26" class="combo"/>
 <text x="67" y="50" class="combo tap">BT</text>
 <text x="67" y="61" class="combo hold">0</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo"/>
 <text x="144" y="37" class="combo tap">BT</text>
 <text x="144" y="48" class="combo hold">1</text>
 </g>
-<g class="combo combopos-34">
+<g class="combo combopos-35">
 <rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo"/>
 <text x="209" y="59" class="combo tap">BT</text>
 <text x="209" y="70" class="combo hold">2</text>
 </g>
-<g class="combo combopos-35">
+<g class="combo combopos-36">
 <rect rx="6" ry="6" x="497" y="46" width="28" height="26" class="combo"/>
 <text x="511" y="59" class="combo tap">
 <tspan x="511" dy="-0.6em">BT</tspan><tspan x="511" dy="1.2em">CLR</tspan>
 </text>
 </g>
-<g class="combo combopos-36">
+<g class="combo combopos-37">
 <rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo"/>
 <text x="575" y="37" class="combo tap">
 <tspan x="575" dy="-0.6em">BT</tspan><tspan x="575" dy="1.2em">…</tspan>

--- a/keymap-drawer/hesse.yaml
+++ b/keymap-drawer/hesse.yaml
@@ -7,6 +7,43 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: sS, type: high}
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: cC, type: medium}
+  - {t: bB, type: medium-low}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - ←
+  - →
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: wW, type: medium}
+  - ↹
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⌫, h: ⇧}
+  - ⇧
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - Num + Nav
+  HD Promethium (AS):
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -127,16 +164,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [4, 5]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [16, 18]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [13, 11]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -155,120 +195,120 @@ combos:
   h: 15.0
 - p: [11, 10]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 19]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [12, 11]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 18]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [16, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12, 11]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [12, 11, 10]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 18, 19]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [13, 12, 11, 10]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18, 19]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [23, 22]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [26, 27]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 2]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [7, 8]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [2, 1]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [22, 21]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [31, 34]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [31, 34]
   k: ⇪
   l: [Naginata]
 - p: [0, 10]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 11]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 12]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 13]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 14]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [6, 5]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 15]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [6, 16]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [7, 17]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 18]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 19]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 13]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 16]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [24, 23]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [25, 26]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 0]
   k: {t: BT, h: '0'}
   l: [Num + Nav]

--- a/keymap-drawer/rugby_union.svg
+++ b/keymap-drawer/rugby_union.svg
@@ -1,4 +1,4 @@
-<svg width="791" height="1399" viewBox="0 0 791 1399" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="791" height="1840" viewBox="0 0 791 1840" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(469, 149) rotate(-44.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(501, 85) rotate(-40.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -428,7 +427,291 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 463)" class="layer-Naginata">
+<g transform="translate(30, 463)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(99, 50) rotate(32.0)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(161, 58) rotate(32.0)" class="key medium-low keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(230, 84) rotate(40.0)" class="key medium keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(262, 148) rotate(44.0)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(285, 209) rotate(44.0)" class="key low keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(446, 209) rotate(-44.0)" class="key medium-low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(469, 149) rotate(-44.0)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(501, 85) rotate(-40.0)" class="key medium-low keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(571, 57) rotate(-32.0)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(632, 51) rotate(-32.0)" class="key low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(55, 108) rotate(22.0)" class="key high keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(132, 103) rotate(32.0)" class="key high keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(197, 126) rotate(40.0)" class="key high keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(226, 188) rotate(44.0)" class="key high keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(249, 249) rotate(44.0)" class="key low keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(482, 249) rotate(-44.0)" class="key medium-low keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(505, 188) rotate(-44.0)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(534, 126) rotate(-40.0)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(599, 104) rotate(-32.0)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(675, 108) rotate(-22.0)" class="key medium keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(36, 158) rotate(22.0)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(104, 148) rotate(32.0)" class="key medium keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(164, 167) rotate(40.0)" class="key medium-high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(190, 227) rotate(44.0)" class="key medium-high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(210, 328) rotate(59.0)" class="key high keypos-24">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(521, 328) rotate(-59.0)" class="key high keypos-25">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g transform="translate(540, 227) rotate(-44.0)" class="key medium-high keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(567, 168) rotate(-40.0)" class="key high keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(627, 149) rotate(-32.0)" class="key medium keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(694, 158) rotate(-22.0)" class="key medium keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g class="combo combopos-0">
+<path d="M575,216 h-65 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M575,216 h18 a6.0,6.0 0 0 0 6.0,-6.0 v-88" class="combo"/>
+<rect rx="6" ry="6" x="561" y="209" width="28" height="15" class="combo"/>
+<text x="575" y="216" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M155,215 h65 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M155,215 h-18 a6.0,6.0 0 0 1 -6.0,-6.0 v-88" class="combo"/>
+<rect rx="6" ry="6" x="141" y="208" width="28" height="15" class="combo"/>
+<text x="155" y="215" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M169,255 h16 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M169,255 l-4,-69" class="combo"/>
+<path d="M169,255 h-59 a6.0,6.0 0 0 1 -6.0,-6.0 v-82" class="combo"/>
+<rect rx="6" ry="6" x="155" y="247" width="28" height="15" class="combo"/>
+<text x="169" y="255" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M605,255 h-59 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M605,255 h-33 a6.0,6.0 0 0 1 -6.0,-6.0 v-63" class="combo"/>
+<path d="M605,255 h16 a6.0,6.0 0 0 0 6.0,-6.0 v-82" class="combo"/>
+<rect rx="6" ry="6" x="591" y="248" width="28" height="15" class="combo"/>
+<text x="605" y="255" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="80" y="92" width="28" height="26" class="combo"/>
+<text x="94" y="105" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="623" y="93" width="28" height="26" class="combo"/>
+<text x="637" y="106" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="150" y="102" width="28" height="26" class="combo"/>
+<text x="164" y="115" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="552" y="102" width="28" height="26" class="combo"/>
+<text x="566" y="115" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="198" y="144" width="28" height="26" class="combo"/>
+<text x="212" y="157" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="505" y="144" width="28" height="26" class="combo"/>
+<text x="519" y="157" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="163" y="184" width="28" height="26" class="combo"/>
+<text x="177" y="197" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="539" y="185" width="28" height="26" class="combo"/>
+<text x="553" y="198" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="232" y="103" width="28" height="26" class="combo low"/>
+<text x="246" y="116" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="522" y="58" width="28" height="26" class="combo low"/>
+<text x="536" y="71" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="182" y="58" width="28" height="26" class="combo low"/>
+<text x="196" y="71" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="120" y="145" width="28" height="26" class="combo low"/>
+<text x="134" y="158" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<path d="M365,328 l-123,0" class="combo"/>
+<path d="M365,328 l123,0" class="combo"/>
+<rect rx="6" ry="6" x="351" y="315" width="28" height="26" class="combo"/>
+<text x="365" y="328" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="63" y="66" width="28" height="26" class="combo"/>
+<text x="77" y="79" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="132" y="68" width="28" height="26" class="combo"/>
+<text x="146" y="81" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="200" y="92" width="28" height="26" class="combo"/>
+<text x="214" y="105" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="230" y="155" width="28" height="26" class="combo"/>
+<text x="244" y="168" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="259" y="166" width="28" height="26" class="combo"/>
+<text x="273" y="179" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M314,229 v-14 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M314,229 v14 a6.0,6.0 0 0 1 -6.0,6.0 h-40" class="combo"/>
+<rect rx="6" ry="6" x="300" y="216" width="28" height="26" class="combo"/>
+<text x="314" y="229" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="444" y="166" width="28" height="26" class="combo"/>
+<text x="458" y="179" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M417,229 v-14 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M417,229 v14 a6.0,6.0 0 0 0 6.0,6.0 h40" class="combo"/>
+<rect rx="6" ry="6" x="403" y="216" width="28" height="26" class="combo"/>
+<text x="417" y="229" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="473" y="156" width="28" height="26" class="combo"/>
+<text x="487" y="169" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="503" y="92" width="28" height="26" class="combo"/>
+<text x="517" y="105" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="571" y="68" width="28" height="26" class="combo"/>
+<text x="585" y="81" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="639" y="66" width="28" height="26" class="combo"/>
+<text x="653" y="79" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="241" y="186" width="28" height="26" class="combo"/>
+<text x="255" y="199" class="combo tap">{</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="461" y="186" width="28" height="26" class="combo"/>
+<text x="475" y="199" class="combo tap">}</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="223" y="205" width="28" height="26" class="combo"/>
+<text x="237" y="218" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="479" y="205" width="28" height="26" class="combo"/>
+<text x="493" y="218" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-39">
+<rect rx="6" ry="6" x="206" y="225" width="28" height="26" class="combo"/>
+<text x="220" y="238" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-40">
+<rect rx="6" ry="6" x="497" y="225" width="28" height="26" class="combo"/>
+<text x="511" y="238" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 903)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(99, 50) rotate(32.0)" class="key keypos-0">
@@ -616,7 +899,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 903)" class="layer-Num + Nav">
+<g transform="translate(30, 1343)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(99, 50) rotate(32.0)" class="key keypos-0">
@@ -745,124 +1028,133 @@ text.right {
 </text>
 </g>
 <g class="combo combopos-0">
+<path d="M365,209 l-62,0" class="combo"/>
+<path d="M365,209 l62,0" class="combo"/>
+<rect rx="6" ry="6" x="351" y="196" width="28" height="26" class="combo"/>
+<text x="365" y="209" class="combo tap">
+<tspan x="365" dy="-0.6em">HD</tspan><tspan x="365" dy="1.2em">…</tspan>
+</text>
+<text x="365" y="220" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M169,255 h16 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <path d="M169,255 l-4,-69" class="combo"/>
 <path d="M169,255 h-59 a6.0,6.0 0 0 1 -6.0,-6.0 v-82" class="combo"/>
 <rect rx="6" ry="6" x="155" y="247" width="28" height="15" class="combo"/>
 <text x="169" y="255" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M605,255 h-59 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M605,255 h-33 a6.0,6.0 0 0 1 -6.0,-6.0 v-63" class="combo"/>
 <path d="M605,255 h16 a6.0,6.0 0 0 0 6.0,-6.0 v-82" class="combo"/>
 <rect rx="6" ry="6" x="591" y="248" width="28" height="15" class="combo"/>
 <text x="605" y="255" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="80" y="92" width="28" height="26" class="combo"/>
 <text x="94" y="105" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="623" y="93" width="28" height="26" class="combo"/>
 <text x="637" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="150" y="102" width="28" height="26" class="combo"/>
 <text x="164" y="115" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="552" y="102" width="28" height="26" class="combo"/>
 <text x="566" y="115" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="198" y="144" width="28" height="26" class="combo"/>
 <text x="212" y="157" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="505" y="144" width="28" height="26" class="combo"/>
 <text x="519" y="157" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="163" y="184" width="28" height="26" class="combo"/>
 <text x="177" y="197" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="539" y="185" width="28" height="26" class="combo"/>
 <text x="553" y="198" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="63" y="66" width="28" height="26" class="combo"/>
 <text x="77" y="79" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="132" y="68" width="28" height="26" class="combo"/>
 <text x="146" y="81" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="200" y="92" width="28" height="26" class="combo"/>
 <text x="214" y="105" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="230" y="155" width="28" height="26" class="combo"/>
 <text x="244" y="168" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="259" y="166" width="28" height="26" class="combo"/>
 <text x="273" y="179" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M314,229 v-14 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M314,229 v14 a6.0,6.0 0 0 1 -6.0,6.0 h-40" class="combo"/>
 <rect rx="6" ry="6" x="300" y="216" width="28" height="26" class="combo"/>
 <text x="314" y="229" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="444" y="166" width="28" height="26" class="combo"/>
 <text x="458" y="179" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M417,229 v-14 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M417,229 v14 a6.0,6.0 0 0 0 6.0,6.0 h40" class="combo"/>
 <rect rx="6" ry="6" x="403" y="216" width="28" height="26" class="combo"/>
 <text x="417" y="229" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="473" y="156" width="28" height="26" class="combo"/>
 <text x="487" y="169" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="503" y="92" width="28" height="26" class="combo"/>
 <text x="517" y="105" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="571" y="68" width="28" height="26" class="combo"/>
 <text x="585" y="81" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="639" y="66" width="28" height="26" class="combo"/>
 <text x="653" y="79" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="241" y="186" width="28" height="26" class="combo"/>
 <text x="255" y="199" class="combo tap">{</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="461" y="186" width="28" height="26" class="combo"/>
 <text x="475" y="199" class="combo tap">}</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="223" y="205" width="28" height="26" class="combo"/>
 <text x="237" y="218" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="479" y="205" width="28" height="26" class="combo"/>
 <text x="493" y="218" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="206" y="225" width="28" height="26" class="combo"/>
 <text x="220" y="238" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="497" y="225" width="28" height="26" class="combo"/>
 <text x="511" y="238" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/rugby_union.yaml
+++ b/keymap-drawer/rugby_union.yaml
@@ -7,6 +7,37 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: sS, type: high}
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: cC, type: medium}
+  - {t: bB, type: medium-low}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: wW, type: medium}
+  HD Promethium (AS):
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -109,16 +140,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [4, 5]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [16, 18]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [13, 11]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -137,123 +171,123 @@ combos:
   h: 15.0
 - p: [11, 10]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 19]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [12, 11]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 18]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [16, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12, 11]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [12, 11, 10]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 18, 19]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [13, 12, 11, 10]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18, 19]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [23, 22]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [26, 27]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 2]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [7, 8]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [2, 1]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [22, 21]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [24, 25]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [24, 25]
   k: ⇪
   l: [Naginata]
 - p: [0, 10]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 11]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 12]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 13]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 14]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [6, 5]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 15]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [6, 16]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [7, 17]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 18]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 19]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 13]
   k: '{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 16]
   k: '}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 13]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 16]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 23]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 26]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]

--- a/keymap-drawer/slump52.svg
+++ b/keymap-drawer/slump52.svg
@@ -1,4 +1,4 @@
-<svg width="922" height="1233" viewBox="0 0 922 1233" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="922" height="1626" viewBox="0 0 922 1626" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -160,7 +160,6 @@ text.right {
 <g transform="translate(437, 77) rotate(-25.0)" class="key keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(491, 54) rotate(-21.0)" class="key medium-low keypos-8">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -517,7 +516,380 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 392)" class="layer-Naginata">
+<g transform="translate(30, 392)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 28)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(85, 30) rotate(3.0)" class="key keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(145, 38) rotate(12.0)" class="key medium-low keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(203, 54) rotate(21.0)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(256, 77) rotate(25.0)" class="key medium keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(295, 126) rotate(25.0)" class="key low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(399, 126) rotate(-25.0)" class="key medium-low keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(437, 77) rotate(-25.0)" class="key keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(491, 54) rotate(-21.0)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(548, 38) rotate(-12.0)" class="key medium-low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(608, 30) rotate(-3.0)" class="key low keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(666, 28)" class="key low keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(722, 28)" class="key keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">7</text>
+</g>
+<g transform="translate(778, 28)" class="key keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">8</text>
+</g>
+<g transform="translate(834, 28)" class="key keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">9</text>
+</g>
+<g transform="translate(28, 84)" class="key keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(102, 88) rotate(7.0)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(177, 105) rotate(19.0)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(232, 128) rotate(25.0)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(272, 177) rotate(25.0)" class="key low keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(422, 177) rotate(-25.0)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(461, 128) rotate(-25.0)" class="key high keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(517, 105) rotate(-19.0)" class="key high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(591, 88) rotate(-7.0)" class="key high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(666, 84)" class="key low keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(722, 84)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">4</text>
+</g>
+<g transform="translate(778, 84)" class="key keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">5</text>
+</g>
+<g transform="translate(834, 84)" class="key keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">6</text>
+</g>
+<g transform="translate(28, 140)" class="key high keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(89, 144) rotate(7.0)" class="key medium keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(151, 157) rotate(16.0)" class="key medium-high keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(209, 179) rotate(25.0)" class="key medium-high keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(248, 228) rotate(25.0)" class="key high keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(446, 228) rotate(-25.0)" class="key high keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g transform="translate(485, 179) rotate(-25.0)" class="key medium-high keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(543, 157) rotate(-16.0)" class="key high keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(604, 144) rotate(-7.0)" class="key medium keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(666, 140)" class="key medium keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(722, 140)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">1</text>
+</g>
+<g transform="translate(778, 140)" class="key keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">2</text>
+</g>
+<g transform="translate(834, 140)" class="key keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">3</text>
+</g>
+<g transform="translate(28, 196)" class="key medium-low keypos-41">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(300, 258) rotate(35.0)" class="key high keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(347, 297) rotate(-45.0)" class="key keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">⇧</text>
+</g>
+<g transform="translate(393, 258) rotate(-35.0)" class="key high keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g transform="translate(547, 301) rotate(-11.5)" class="key keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">←</text>
+</g>
+<g transform="translate(602, 290) rotate(-11.5)" class="key keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">↓</text>
+</g>
+<g transform="translate(591, 236) rotate(-11.5)" class="key keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">↑</text>
+</g>
+<g transform="translate(657, 279) rotate(-11.5)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">→</text>
+</g>
+<g transform="translate(666, 196)" class="key medium keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g transform="translate(722, 196)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">0</text>
+</g>
+<g transform="translate(806, 204)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">RET</text>
+</g>
+<g class="combo combopos-0">
+<path d="M558,156 h-91 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M558,156 h26 a6.0,6.0 0 0 0 6.0,-6.0 v-42" class="combo"/>
+<rect rx="6" ry="6" x="544" y="148" width="28" height="15" class="combo"/>
+<text x="558" y="156" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M135,156 h91 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M135,156 h-26 a6.0,6.0 0 0 1 -6.0,-6.0 v-42" class="combo"/>
+<rect rx="6" ry="6" x="121" y="148" width="28" height="15" class="combo"/>
+<text x="135" y="156" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M119,207 h84 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M119,207 h26 a6.0,6.0 0 0 0 6.0,-6.0 v-25" class="combo"/>
+<path d="M119,207 h-24 a6.0,6.0 0 0 1 -6.0,-6.0 v-38" class="combo"/>
+<rect rx="6" ry="6" x="105" y="199" width="28" height="15" class="combo"/>
+<text x="119" y="207" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M515,207 h-24 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M515,207 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-25" class="combo"/>
+<path d="M515,207 h83 a6.0,6.0 0 0 0 6.0,-6.0 v-38" class="combo"/>
+<rect rx="6" ry="6" x="501" y="199" width="28" height="15" class="combo"/>
+<text x="515" y="207" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="51" y="101" width="28" height="26" class="combo"/>
+<text x="65" y="114" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="614" y="101" width="28" height="26" class="combo"/>
+<text x="628" y="114" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
+<text x="140" y="97" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="540" y="84" width="28" height="26" class="combo"/>
+<text x="554" y="97" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
+<text x="205" y="116" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
+<text x="489" y="116" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
+<text x="180" y="168" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
+<text x="514" y="168" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="216" y="53" width="28" height="26" class="combo low"/>
+<text x="230" y="66" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="505" y="33" width="28" height="26" class="combo low"/>
+<text x="519" y="46" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="160" y="33" width="28" height="26" class="combo low"/>
+<text x="174" y="46" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="106" y="137" width="28" height="26" class="combo low"/>
+<text x="120" y="150" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<rect rx="6" ry="6" x="333" y="245" width="28" height="26" class="combo"/>
+<text x="347" y="258" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
+<text x="28" y="112" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
+<text x="124" y="63" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
+<text x="190" y="80" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
+<text x="244" y="102" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
+<text x="276" y="102" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
+<rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
+<text x="324" y="151" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
+<text x="418" y="102" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
+<rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
+<text x="370" y="151" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
+<text x="449" y="102" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
+<text x="504" y="80" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
+<text x="570" y="63" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
+<text x="666" y="112" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
+<text x="264" y="127" class="combo tap">{</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
+<text x="430" y="127" class="combo tap">}</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
+<text x="252" y="152" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
+<text x="442" y="152" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-39">
+<rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
+<text x="240" y="178" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-40">
+<rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
+<text x="454" y="178" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 785)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 28)" class="key keypos-0">
@@ -797,7 +1169,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 785)" class="layer-Num + Nav">
+<g transform="translate(30, 1177)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 28)" class="key keypos-0">
@@ -1015,124 +1387,131 @@ text.right {
 <text x="0" y="0" class="key tap">RET</text>
 </g>
 <g class="combo combopos-0">
+<rect rx="6" ry="6" x="333" y="113" width="28" height="26" class="combo"/>
+<text x="347" y="126" class="combo tap">
+<tspan x="347" dy="-0.6em">HD</tspan><tspan x="347" dy="1.2em">…</tspan>
+</text>
+<text x="347" y="137" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M119,207 h84 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <path d="M119,207 h26 a6.0,6.0 0 0 0 6.0,-6.0 v-25" class="combo"/>
 <path d="M119,207 h-24 a6.0,6.0 0 0 1 -6.0,-6.0 v-38" class="combo"/>
 <rect rx="6" ry="6" x="105" y="199" width="28" height="15" class="combo"/>
 <text x="119" y="207" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M515,207 h-24 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M515,207 h22 a6.0,6.0 0 0 0 6.0,-6.0 v-25" class="combo"/>
 <path d="M515,207 h83 a6.0,6.0 0 0 0 6.0,-6.0 v-38" class="combo"/>
 <rect rx="6" ry="6" x="501" y="199" width="28" height="15" class="combo"/>
 <text x="515" y="207" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="51" y="101" width="28" height="26" class="combo"/>
 <text x="65" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="614" y="101" width="28" height="26" class="combo"/>
 <text x="628" y="114" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="126" y="84" width="28" height="26" class="combo"/>
 <text x="140" y="97" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="540" y="84" width="28" height="26" class="combo"/>
 <text x="554" y="97" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="191" y="103" width="28" height="26" class="combo"/>
 <text x="205" y="116" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="475" y="103" width="28" height="26" class="combo"/>
 <text x="489" y="116" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="166" y="155" width="28" height="26" class="combo"/>
 <text x="180" y="168" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="500" y="155" width="28" height="26" class="combo"/>
 <text x="514" y="168" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="14" y="99" width="28" height="26" class="combo"/>
 <text x="28" y="112" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="110" y="50" width="28" height="26" class="combo"/>
 <text x="124" y="63" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="176" y="67" width="28" height="26" class="combo"/>
 <text x="190" y="80" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="230" y="89" width="28" height="26" class="combo"/>
 <text x="244" y="102" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="262" y="89" width="28" height="26" class="combo"/>
 <text x="276" y="102" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M324,151 v-19 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M324,151 v19 a6.0,6.0 0 0 1 -6.0,6.0 h-28" class="combo"/>
 <rect rx="6" ry="6" x="310" y="138" width="28" height="26" class="combo"/>
 <text x="324" y="151" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="404" y="89" width="28" height="26" class="combo"/>
 <text x="418" y="102" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M370,151 v-19 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M370,151 v19 a6.0,6.0 0 0 0 6.0,6.0 h28" class="combo"/>
 <rect rx="6" ry="6" x="356" y="138" width="28" height="26" class="combo"/>
 <text x="370" y="151" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="435" y="89" width="28" height="26" class="combo"/>
 <text x="449" y="102" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="490" y="67" width="28" height="26" class="combo"/>
 <text x="504" y="80" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="556" y="50" width="28" height="26" class="combo"/>
 <text x="570" y="63" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="652" y="99" width="28" height="26" class="combo"/>
 <text x="666" y="112" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="250" y="114" width="28" height="26" class="combo"/>
 <text x="264" y="127" class="combo tap">{</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="416" y="114" width="28" height="26" class="combo"/>
 <text x="430" y="127" class="combo tap">}</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="238" y="139" width="28" height="26" class="combo"/>
 <text x="252" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="428" y="139" width="28" height="26" class="combo"/>
 <text x="442" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-32">
+<g class="combo combopos-33">
 <rect rx="6" ry="6" x="226" y="165" width="28" height="26" class="combo"/>
 <text x="240" y="178" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-33">
+<g class="combo combopos-34">
 <rect rx="6" ry="6" x="440" y="165" width="28" height="26" class="combo"/>
 <text x="454" y="178" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/slump52.yaml
+++ b/keymap-drawer/slump52.yaml
@@ -8,6 +8,59 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: =+, type: low}
+  - '7'
+  - '8'
+  - '9'
+  - ⎋
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: =+, type: low}
+  - '4'
+  - '5'
+  - '6'
+  - {t: sS, type: high}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: cC, type: medium}
+  - '1'
+  - '2'
+  - '3'
+  - {t: bB, type: medium-low}
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⌫, h: ⇧}
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - ←
+  - ↓
+  - ↑
+  - →
+  - {t: wW, type: medium}
+  - '0'
+  - RET
+  HD Promethium (AS):
+  - ⎋
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -175,16 +228,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [5, 6]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [21, 23]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [18, 16]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -203,123 +259,123 @@ combos:
   h: 15.0
 - p: [16, 28]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [23, 37]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 16]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [22, 23]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [21, 22]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 17, 16]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [21, 22, 23]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 16, 28]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [22, 23, 37]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [18, 17, 16, 28]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [21, 22, 23, 37]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [31, 30]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [34, 35]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [8, 9]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [3, 2]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [30, 29]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [42, 44]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [42, 44]
   k: ⇪
   l: [Naginata]
 - p: [15, 28]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 16]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 17]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 18]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 4]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 19]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [7, 6]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [6, 20]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [7, 21]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 22]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 23]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [24, 37]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 18]
   k: '{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [6, 21]
   k: '}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [19, 18]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [20, 21]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [19, 31]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [20, 34]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]

--- a/keymap-drawer/tc36k.svg
+++ b/keymap-drawer/tc36k.svg
@@ -1,4 +1,4 @@
-<svg width="780" height="1303" viewBox="0 0 780 1303" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="780" height="1718" viewBox="0 0 780 1718" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags*/
 svg path {
     fill: inherit;
@@ -156,7 +156,6 @@ text.right {
 <g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">⌫</text>
-<text x="0" y="24" class="key hold">Sft+⌫</text>
 </g>
 <g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
@@ -448,7 +447,311 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 416)" class="layer-Naginata">
+<g transform="translate(30, 416)" class="layer-HD Promethium (AS)">
+<text x="0" y="28" class="label" id="HD-Promethium-AS">HD Promethium (AS)</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 63)" class="key keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⎋</text>
+</g>
+<g transform="translate(106, 38) rotate(10.0)" class="key medium-low keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">pP</text>
+</g>
+<g transform="translate(183, 35) rotate(18.0)" class="key medium keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">gG</text>
+</g>
+<g transform="translate(235, 82) rotate(22.0)" class="key medium keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">mM</text>
+</g>
+<g transform="translate(282, 117) rotate(22.0)" class="key low keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">kK</text>
+</g>
+<g transform="translate(437, 117) rotate(-22.0)" class="key medium-low keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">.:</text>
+</g>
+<g transform="translate(484, 82) rotate(-22.0)" class="key keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">Sft+⌫</text>
+</g>
+<g transform="translate(537, 35) rotate(-18.0)" class="key medium-low keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">&#x27;&quot;</text>
+</g>
+<g transform="translate(613, 38) rotate(-10.0)" class="key medium-low keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">-_</text>
+</g>
+<g transform="translate(692, 63)" class="key low keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">=+</text>
+</g>
+<g transform="translate(28, 119)" class="key high keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">sS</text>
+</g>
+<g transform="translate(97, 93) rotate(10.0)" class="key high keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">nN</text>
+</g>
+<g transform="translate(166, 88) rotate(18.0)" class="key high keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">tT</text>
+</g>
+<g transform="translate(215, 134) rotate(22.0)" class="key high keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">hH</text>
+</g>
+<g transform="translate(262, 169) rotate(22.0)" class="key low keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key low"/>
+<text x="0" y="0" class="key low tap">jJ</text>
+</g>
+<g transform="translate(458, 169) rotate(-22.0)" class="key medium-low keypos-15">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">,;</text>
+</g>
+<g transform="translate(505, 134) rotate(-22.0)" class="key high keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">aA</text>
+</g>
+<g transform="translate(554, 88) rotate(-18.0)" class="key high keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">eE</text>
+</g>
+<g transform="translate(622, 93) rotate(-10.0)" class="key high keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">iI</text>
+</g>
+<g transform="translate(692, 119)" class="key medium keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">cC</text>
+</g>
+<g transform="translate(28, 175)" class="key medium-low keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-low"/>
+<text x="0" y="0" class="key medium-low tap">bB</text>
+</g>
+<g transform="translate(88, 148) rotate(10.0)" class="key medium keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">fF</text>
+</g>
+<g transform="translate(150, 142) rotate(18.0)" class="key medium-high keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">dD</text>
+</g>
+<g transform="translate(195, 186) rotate(22.0)" class="key medium-high keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">lL</text>
+</g>
+<g transform="translate(242, 221) rotate(22.0)" class="key keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">←</text>
+</g>
+<g transform="translate(477, 221) rotate(-22.0)" class="key keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">→</text>
+</g>
+<g transform="translate(524, 186) rotate(-22.0)" class="key medium-high keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium-high"/>
+<text x="0" y="0" class="key medium-high tap">uU</text>
+</g>
+<g transform="translate(570, 142) rotate(-18.0)" class="key high keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">oO</text>
+</g>
+<g transform="translate(632, 148) rotate(-10.0)" class="key medium keypos-28">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">yY</text>
+</g>
+<g transform="translate(692, 175)" class="key medium keypos-29">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key medium"/>
+<text x="0" y="0" class="key medium tap">wW</text>
+</g>
+<g transform="translate(143, 241) rotate(22.0)" class="key keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">↹</text>
+</g>
+<g transform="translate(199, 274) rotate(37.0)" class="key high keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">rR</text>
+<text x="0" y="24" class="key high hold">⇧</text>
+</g>
+<g transform="translate(244, 320) rotate(38.0)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌫</text>
+<text x="0" y="24" class="key hold">⇧</text>
+</g>
+<g transform="translate(475, 320) rotate(-38.0)" class="key keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⇧</text>
+</g>
+<g transform="translate(521, 274) rotate(-37.0)" class="key high keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key high"/>
+<text x="0" y="0" class="key high tap">⎵R</text>
+<text x="0" y="24" class="key high hold">Num+Nav</text>
+</g>
+<g transform="translate(576, 241) rotate(-22.0)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Num--Nav">
+<text x="0" y="0" class="key tap layer-activator">
+<tspan x="0" dy="-1.2em">Num</tspan><tspan x="0" dy="1.2em">+</tspan><tspan x="0" dy="1.2em">Nav</tspan>
+</text>
+</a></g>
+<g class="combo combopos-0">
+<path d="M593,162 h-82 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M593,162 h23 a6.0,6.0 0 0 0 6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="579" y="155" width="28" height="15" class="combo"/>
+<text x="593" y="162" class="combo tap">かな</text>
+</g>
+<g class="combo combopos-1">
+<path d="M127,162 h82 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M127,162 h-23 a6.0,6.0 0 0 1 -6.0,-6.0 v-45" class="combo"/>
+<rect rx="6" ry="6" x="113" y="155" width="28" height="15" class="combo"/>
+<text x="127" y="162" class="combo tap">ABC</text>
+</g>
+<g class="combo combopos-2">
+<path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
+<path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
+<text x="169" y="214" class="combo tap">↹</text>
+</g>
+<g class="combo combopos-3">
+<path d="M605,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
+<path d="M605,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
+<path d="M605,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
+<rect rx="6" ry="6" x="591" y="207" width="28" height="15" class="combo"/>
+<text x="605" y="214" class="combo tap">⏎</text>
+</g>
+<g class="combo combopos-4">
+<rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
+<text x="63" y="106" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-5">
+<rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
+<text x="657" y="106" class="combo tap">⎇</text>
+</g>
+<g class="combo combopos-6">
+<rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
+<text x="132" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-7">
+<rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
+<text x="588" y="91" class="combo tap">⌃</text>
+</g>
+<g class="combo combopos-8">
+<rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
+<text x="190" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-9">
+<rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
+<text x="529" y="111" class="combo tap">⌘</text>
+</g>
+<g class="combo combopos-16">
+<rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
+<text x="172" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo combopos-17">
+<rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
+<text x="547" y="164" class="combo tap">⇧</text>
+</g>
+<g class="combo low combopos-18">
+<rect rx="6" ry="6" x="195" y="46" width="28" height="26" class="combo low"/>
+<text x="209" y="59" class="combo low tap">qQ</text>
+</g>
+<g class="combo low combopos-19">
+<rect rx="6" ry="6" x="561" y="24" width="28" height="26" class="combo low"/>
+<text x="575" y="37" class="combo low tap">zZ</text>
+</g>
+<g class="combo low combopos-20">
+<rect rx="6" ry="6" x="130" y="24" width="28" height="26" class="combo low"/>
+<text x="144" y="37" class="combo low tap">vV</text>
+</g>
+<g class="combo low combopos-21">
+<rect rx="6" ry="6" x="105" y="132" width="28" height="26" class="combo low"/>
+<text x="119" y="145" class="combo low tap">xX</text>
+</g>
+<g class="combo combopos-22">
+<path d="M360,274 l-142,0" class="combo"/>
+<path d="M360,274 l142,0" class="combo"/>
+<rect rx="6" ry="6" x="346" y="261" width="28" height="26" class="combo"/>
+<text x="360" y="274" class="combo tap">⇪</text>
+</g>
+<g class="combo combopos-23">
+<rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
+<text x="28" y="91" class="combo tap">`</text>
+</g>
+<g class="combo combopos-24">
+<rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
+<text x="102" y="66" class="combo tap">@</text>
+</g>
+<g class="combo combopos-25">
+<rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
+<text x="174" y="62" class="combo tap">|</text>
+</g>
+<g class="combo combopos-26">
+<rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
+<text x="225" y="108" class="combo tap">$</text>
+</g>
+<g class="combo combopos-27">
+<rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
+<text x="258" y="100" class="combo tap">\</text>
+</g>
+<g class="combo combopos-28">
+<path d="M311,143 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
+<path d="M311,143 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
+<rect rx="6" ry="6" x="297" y="130" width="28" height="26" class="combo"/>
+<text x="311" y="143" class="combo tap">%</text>
+</g>
+<g class="combo combopos-29">
+<rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
+<text x="461" y="100" class="combo tap">/</text>
+</g>
+<g class="combo combopos-30">
+<path d="M408,143 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
+<path d="M408,143 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
+<rect rx="6" ry="6" x="394" y="130" width="28" height="26" class="combo"/>
+<text x="408" y="143" class="combo tap">^</text>
+</g>
+<g class="combo combopos-31">
+<rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
+<text x="494" y="108" class="combo tap">?</text>
+</g>
+<g class="combo combopos-32">
+<rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
+<text x="545" y="62" class="combo tap">#</text>
+</g>
+<g class="combo combopos-33">
+<rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
+<text x="618" y="66" class="combo tap">!</text>
+</g>
+<g class="combo combopos-34">
+<rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
+<text x="692" y="91" class="combo tap">~</text>
+</g>
+<g class="combo combopos-35">
+<rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
+<text x="239" y="152" class="combo tap">(&lt;</text>
+</g>
+<g class="combo combopos-36">
+<rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
+<text x="481" y="152" class="combo tap">)&gt;</text>
+</g>
+<g class="combo combopos-37">
+<rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
+<text x="219" y="204" class="combo tap">[{</text>
+</g>
+<g class="combo combopos-38">
+<rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
+<text x="501" y="204" class="combo tap">]}</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 831)" class="layer-Naginata">
 <text x="0" y="28" class="label" id="Naginata">Naginata</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 63)" class="key keypos-0">
@@ -664,7 +967,7 @@ text.right {
 </g>
 </g>
 </g>
-<g transform="translate(30, 831)" class="layer-Num + Nav">
+<g transform="translate(30, 1247)" class="layer-Num + Nav">
 <text x="0" y="28" class="label" id="Num--Nav">Num + Nav</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 63)" class="key keypos-0">
@@ -816,116 +1119,125 @@ text.right {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
 </g>
 <g class="combo combopos-0">
+<path d="M360,117 l-59,0" class="combo"/>
+<path d="M360,117 l59,0" class="combo"/>
+<rect rx="6" ry="6" x="346" y="104" width="28" height="26" class="combo"/>
+<text x="360" y="117" class="combo tap">
+<tspan x="360" dy="-0.6em">HD</tspan><tspan x="360" dy="1.2em">…</tspan>
+</text>
+<text x="360" y="128" class="combo hold">toggle</text>
+</g>
+<g class="combo combopos-1">
 <path d="M169,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-3" class="combo"/>
 <path d="M169,214 h-13 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M169,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="155" y="207" width="28" height="15" class="combo"/>
 <text x="169" y="214" class="combo tap">↹</text>
 </g>
-<g class="combo combopos-1">
+<g class="combo combopos-2">
 <path d="M605,214 h-75 a6.0,6.0 0 0 1 -6.0,-6.0 v-3" class="combo"/>
 <path d="M605,214 h-29 a6.0,6.0 0 0 1 -6.0,-6.0 v-48" class="combo"/>
 <path d="M605,214 h21 a6.0,6.0 0 0 0 6.0,-6.0 v-41" class="combo"/>
 <rect rx="6" ry="6" x="591" y="207" width="28" height="15" class="combo"/>
 <text x="605" y="214" class="combo tap">⏎</text>
 </g>
-<g class="combo combopos-2">
+<g class="combo combopos-3">
 <rect rx="6" ry="6" x="49" y="93" width="28" height="26" class="combo"/>
 <text x="63" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-3">
+<g class="combo combopos-4">
 <rect rx="6" ry="6" x="643" y="93" width="28" height="26" class="combo"/>
 <text x="657" y="106" class="combo tap">⎇</text>
 </g>
-<g class="combo combopos-4">
+<g class="combo combopos-5">
 <rect rx="6" ry="6" x="118" y="78" width="28" height="26" class="combo"/>
 <text x="132" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-5">
+<g class="combo combopos-6">
 <rect rx="6" ry="6" x="574" y="78" width="28" height="26" class="combo"/>
 <text x="588" y="91" class="combo tap">⌃</text>
 </g>
-<g class="combo combopos-6">
+<g class="combo combopos-7">
 <rect rx="6" ry="6" x="176" y="98" width="28" height="26" class="combo"/>
 <text x="190" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-7">
+<g class="combo combopos-8">
 <rect rx="6" ry="6" x="515" y="98" width="28" height="26" class="combo"/>
 <text x="529" y="111" class="combo tap">⌘</text>
 </g>
-<g class="combo combopos-14">
+<g class="combo combopos-15">
 <rect rx="6" ry="6" x="158" y="151" width="28" height="26" class="combo"/>
 <text x="172" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-15">
+<g class="combo combopos-16">
 <rect rx="6" ry="6" x="533" y="151" width="28" height="26" class="combo"/>
 <text x="547" y="164" class="combo tap">⇧</text>
 </g>
-<g class="combo combopos-16">
+<g class="combo combopos-17">
 <rect rx="6" ry="6" x="14" y="78" width="28" height="26" class="combo"/>
 <text x="28" y="91" class="combo tap">`</text>
 </g>
-<g class="combo combopos-17">
+<g class="combo combopos-18">
 <rect rx="6" ry="6" x="88" y="53" width="28" height="26" class="combo"/>
 <text x="102" y="66" class="combo tap">@</text>
 </g>
-<g class="combo combopos-18">
+<g class="combo combopos-19">
 <rect rx="6" ry="6" x="160" y="49" width="28" height="26" class="combo"/>
 <text x="174" y="62" class="combo tap">|</text>
 </g>
-<g class="combo combopos-19">
+<g class="combo combopos-20">
 <rect rx="6" ry="6" x="211" y="95" width="28" height="26" class="combo"/>
 <text x="225" y="108" class="combo tap">$</text>
 </g>
-<g class="combo combopos-20">
+<g class="combo combopos-21">
 <rect rx="6" ry="6" x="244" y="87" width="28" height="26" class="combo"/>
 <text x="258" y="100" class="combo tap">\</text>
 </g>
-<g class="combo combopos-21">
+<g class="combo combopos-22">
 <path d="M311,143 v-20 a6.0,6.0 0 0 0 -6.0,-6.0 h-4" class="combo"/>
 <path d="M311,143 v20 a6.0,6.0 0 0 1 -6.0,6.0 h-24" class="combo"/>
 <rect rx="6" ry="6" x="297" y="130" width="28" height="26" class="combo"/>
 <text x="311" y="143" class="combo tap">%</text>
 </g>
-<g class="combo combopos-22">
+<g class="combo combopos-23">
 <rect rx="6" ry="6" x="447" y="87" width="28" height="26" class="combo"/>
 <text x="461" y="100" class="combo tap">/</text>
 </g>
-<g class="combo combopos-23">
+<g class="combo combopos-24">
 <path d="M408,143 v-20 a6.0,6.0 0 0 1 6.0,-6.0 h4" class="combo"/>
 <path d="M408,143 v20 a6.0,6.0 0 0 0 6.0,6.0 h24" class="combo"/>
 <rect rx="6" ry="6" x="394" y="130" width="28" height="26" class="combo"/>
 <text x="408" y="143" class="combo tap">^</text>
 </g>
-<g class="combo combopos-24">
+<g class="combo combopos-25">
 <rect rx="6" ry="6" x="480" y="95" width="28" height="26" class="combo"/>
 <text x="494" y="108" class="combo tap">?</text>
 </g>
-<g class="combo combopos-25">
+<g class="combo combopos-26">
 <rect rx="6" ry="6" x="531" y="49" width="28" height="26" class="combo"/>
 <text x="545" y="62" class="combo tap">#</text>
 </g>
-<g class="combo combopos-26">
+<g class="combo combopos-27">
 <rect rx="6" ry="6" x="604" y="53" width="28" height="26" class="combo"/>
 <text x="618" y="66" class="combo tap">!</text>
 </g>
-<g class="combo combopos-27">
+<g class="combo combopos-28">
 <rect rx="6" ry="6" x="678" y="78" width="28" height="26" class="combo"/>
 <text x="692" y="91" class="combo tap">~</text>
 </g>
-<g class="combo combopos-28">
+<g class="combo combopos-29">
 <rect rx="6" ry="6" x="225" y="139" width="28" height="26" class="combo"/>
 <text x="239" y="152" class="combo tap">(&lt;</text>
 </g>
-<g class="combo combopos-29">
+<g class="combo combopos-30">
 <rect rx="6" ry="6" x="467" y="139" width="28" height="26" class="combo"/>
 <text x="481" y="152" class="combo tap">)&gt;</text>
 </g>
-<g class="combo combopos-30">
+<g class="combo combopos-31">
 <rect rx="6" ry="6" x="205" y="191" width="28" height="26" class="combo"/>
 <text x="219" y="204" class="combo tap">[{</text>
 </g>
-<g class="combo combopos-31">
+<g class="combo combopos-32">
 <rect rx="6" ry="6" x="487" y="191" width="28" height="26" class="combo"/>
 <text x="501" y="204" class="combo tap">]}</text>
 </g>

--- a/keymap-drawer/tc36k.yaml
+++ b/keymap-drawer/tc36k.yaml
@@ -7,6 +7,43 @@ layers:
   - {t: mM, type: medium}
   - {t: kK, type: low}
   - {t: '.:', type: medium-low}
+  - ⌫
+  - {t: '''"', type: medium-low}
+  - {t: -_, type: medium-low}
+  - {t: =+, type: low}
+  - {t: sS, type: high}
+  - {t: nN, type: high}
+  - {t: tT, type: high}
+  - {t: hH, type: high}
+  - {t: jJ, type: low}
+  - {t: ',;', type: medium-low}
+  - {t: aA, type: high}
+  - {t: eE, type: high}
+  - {t: iI, type: high}
+  - {t: cC, type: medium}
+  - {t: bB, type: medium-low}
+  - {t: fF, type: medium}
+  - {t: dD, type: medium-high}
+  - {t: lL, type: medium-high}
+  - ←
+  - →
+  - {t: uU, type: medium-high}
+  - {t: oO, type: high}
+  - {t: yY, type: medium}
+  - {t: wW, type: medium}
+  - ↹
+  - {t: rR, h: ⇧, type: high}
+  - {t: ⌫, h: ⇧}
+  - ⇧
+  - {t: ⎵R, h: Num+Nav, type: high}
+  - Num + Nav
+  HD Promethium (AS):
+  - ⎋
+  - {t: pP, type: medium-low}
+  - {t: gG, type: medium}
+  - {t: mM, type: medium}
+  - {t: kK, type: low}
+  - {t: '.:', type: medium-low}
   - {t: ⌫, h: Sft+⌫}
   - {t: '''"', type: medium-low}
   - {t: -_, type: medium-low}
@@ -127,16 +164,19 @@ combos:
   l: [HD Promethium]
   a: bottom
   w: 50.0
+- p: [4, 5]
+  k: {t: HD Promethium (AS), h: toggle}
+  l: [Num + Nav]
 - p: [16, 18]
   k: かな
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: 0.5
   h: 15.0
 - p: [13, 11]
   k: ABC
-  l: [HD Promethium, Naginata]
+  l: [HD Promethium, HD Promethium (AS), Naginata]
   a: bottom
   o: -0.02
   s: -0.5
@@ -155,117 +195,117 @@ combos:
   h: 15.0
 - p: [11, 10]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [18, 19]
   k: ⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [12, 11]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [17, 18]
   k: ⌃
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [16, 17]
   k: ⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [13, 12, 11]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18]
   k: Ctl+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [12, 11, 10]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [17, 18, 19]
   k: Ctl+⎇
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [13, 12, 11, 10]
   k: Ctl+Alt+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [16, 17, 18, 19]
   k: Ctl+AltGr+⌘
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   hidden: true
 - p: [23, 22]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [26, 27]
   k: ⇧
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 2]
   k: {t: qQ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [7, 8]
   k: {t: zZ, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [2, 1]
   k: {t: vV, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [22, 21]
   k: {t: xX, type: low}
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [31, 34]
   k: ⇪
-  l: [HD Promethium]
+  l: [HD Promethium, HD Promethium (AS)]
 - p: [31, 34]
   k: ⇪
   l: [Naginata]
 - p: [0, 10]
   k: '`'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [1, 11]
   k: '@'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [2, 12]
   k: '|'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [3, 13]
   k: $
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 3]
   k: \
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [4, 14]
   k: '%'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: right
 - p: [6, 5]
   k: /
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [5, 15]
   k: ^
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
   a: left
 - p: [6, 16]
   k: '?'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [7, 17]
   k: '#'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [8, 18]
   k: '!'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [9, 19]
   k: '~'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [14, 13]
   k: (<
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [15, 16]
   k: )>
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [24, 23]
   k: '[{'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]
 - p: [25, 26]
   k: ']}'
-  l: [HD Promethium, Num + Nav]
+  l: [HD Promethium, HD Promethium (AS), Num + Nav]

--- a/keymap_drawer.config.yaml
+++ b/keymap_drawer.config.yaml
@@ -135,6 +135,7 @@ parse_config:
   zmk_combos:
     caps_lock_combo: {'key': '⇪'}
     caps_word_combo: {'key': '⇪'}
+    auto_shift_combo: {'key': 'AS'}
     combo_studio_unlock: {'key': 'Studio Unlock', 'align': 'top', 'offset': 0.3, 'width': 50}
     combo_bootloader: {'key': 'Boot loader', 'align': 'bottom', 'width': 50}
     tab_combo: {'align': 'bottom', 'offset': -0.02, 'slide': -0.5, 'height': 15}


### PR DESCRIPTION
I first added auto-shift in #15, turned it off in #24, turned it on for second time in #34, turned it off in #35, turned it on again in #36.

This makes it a toggle via an extra base layer. Note leaving the Japanese layer currently reverts to the base layer (without auto-shift on the letters).